### PR TITLE
Support application/x-www-form-urlencoded token requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ You can theoretically register a hook that overwrites internal session fields li
 | optionalClaims | `string[]` (optional) | - | Claims to be extracted from the id token |
 | logoutUrl | `string` (optional) | '' | Logout endpoint URL |
 | scopeInTokenRequest | `boolean` (optional) | false | Include scope in token request |
-| tokenRequestType | `'form'` \| `'json'` (optional) | `'form'` | Token request type |
+| tokenRequestType | `'form'` \| `'form-urlencoded'` \| `'json'` (optional) | `'form'` | Token request type |
 | audience | `string` (optional) | - | Audience used for token validation (not included in requests by default, use additionalTokenParameters or additionalAuthParameters to add it) |
 | requiredProperties | `string`[] | - | Required properties of the configuration that will be validated at runtime. |
 | filterUserinfo | `string[]`(optional) | - | Filter userinfo response to only include these properties. |

--- a/src/runtime/server/lib/oidc.ts
+++ b/src/runtime/server/lib/oidc.ts
@@ -135,7 +135,7 @@ export function callbackEventHandler({ onSuccess, onError }: OAuthConfig<UserSes
     }
 
     // Set Content-Type header
-    headers['content-type'] = getTokenRequestContentType(config.tokenRequestType)
+    headers['content-type'] = getTokenRequestContentType(config.tokenRequestType ?? undefined)
 
     // Construct form data for token request
     const requestBody: TokenRequest = {
@@ -157,7 +157,7 @@ export function callbackEventHandler({ onSuccess, onError }: OAuthConfig<UserSes
         {
           method: 'POST',
           headers,
-          body: convertTokenRequestToType(requestBody, config.tokenRequestType)
+          body: convertTokenRequestToType(requestBody, config.tokenRequestType ?? undefined)
         }
       )
     } catch (error: any) {

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -107,28 +107,30 @@ export function generateFormUrlEncodedRequest(requestValues: RefreshTokenRequest
   return new URLSearchParams(requestEntries).toString()
 }
 
-export function convertTokenRequestToType(requestValues: RefreshTokenRequest | TokenRequest, requestType: OidcProviderConfig['tokenRequestType'] | null | void) {
+export function convertTokenRequestToType(
+  requestValues: RefreshTokenRequest | TokenRequest, 
+  requestType: OidcProviderConfig['tokenRequestType'] = 'form',
+) {
   switch (requestType) {
     case 'json':
       return requestValues
     case 'form-urlencoded':
       return generateFormUrlEncodedRequest(requestValues)
-    case 'form':
     default:
       return generateFormDataRequest(requestValues)
   }
 }
 
-export function getTokenRequestContentType(requestType: OidcProviderConfig['tokenRequestType'] | null | void) {
-  switch (requestType) {
-    case 'json':
-      return 'application/json'
-    case 'form-urlencoded':
-      return 'application/x-www-form-urlencoded'
-    case 'form':
-    default:
-      return 'multipart/form-data'
-  }
+export function getTokenRequestContentType(
+  requestType: OidcProviderConfig['tokenRequestType'] = 'form',
+) {
+  return (
+    {
+      json: 'application/json',
+      form: 'multipart/form-data',
+      'form-urlencoded': 'application/x-www-form-urlencoded',
+    }[requestType]
+  )
 }
 
 export function convertObjectToSnakeCase(object: Record<string, any>) {

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -31,6 +31,9 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     const encodedCredentials = genBase64FromString(`${config.clientId}:${config.clientSecret}`)
     headers.authorization = `Basic ${encodedCredentials}`
   }
+  
+  // Set Content-Type header
+  headers['content-type'] = getTokenRequestContentType(config.tokenRequestType)
 
   // Construct form data for refresh token request
   const requestBody: RefreshTokenRequest = {
@@ -40,7 +43,6 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     ...(config.scopeInTokenRequest && config.scope) && { scope: config.scope.join(' ') },
     ...(config.authenticationScheme === 'body') && { client_secret: normalizeURL(config.clientSecret) }
   }
-  const requestForm = generateFormDataRequest(requestBody)
 
   // Make refresh token request
   let tokenResponse: TokenRespose
@@ -50,11 +52,11 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
       {
         method: 'POST',
         headers,
-        body: config.tokenRequestType === 'json' ? requestBody : requestForm,
+        body: convertTokenRequestToType(requestBody, config.tokenRequestType)
       }
     )
   } catch (error: any) {
-    logger.error(error.data) // Log ofetch error data to console
+    logger.error(error?.data ?? error) // Log ofetch error data to console
     throw new Error('Failed to refresh token')
   }
 
@@ -98,6 +100,35 @@ export function generateFormDataRequest(requestValues: RefreshTokenRequest | Tok
     requestBody.append(key, normalizeURL(requestValues[(key as keyof typeof requestValues)] as string))
   })
   return requestBody
+}
+
+export function generateFormUrlEncodedRequest(requestValues: RefreshTokenRequest | TokenRequest) {
+  const requestEntries = Object.entries(requestValues).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  return new URLSearchParams(requestEntries).toString()
+}
+
+export function convertTokenRequestToType(requestValues: RefreshTokenRequest | TokenRequest, requestType: OidcProviderConfig['tokenRequestType'] | null | void) {
+  switch (requestType) {
+    case 'json':
+      return requestValues
+    case 'form-urlencoded':
+      return generateFormUrlEncodedRequest(requestValues)
+    case 'form':
+    default:
+      return generateFormDataRequest(requestValues)
+  }
+}
+
+export function getTokenRequestContentType(requestType: OidcProviderConfig['tokenRequestType'] | null | void) {
+  switch (requestType) {
+    case 'json':
+      return 'application/json'
+    case 'form-urlencoded':
+      return 'application/x-www-form-urlencoded'
+    case 'form':
+    default:
+      return 'multipart/form-data'
+  }
 }
 
 export function convertObjectToSnakeCase(object: Record<string, any>) {

--- a/src/runtime/types/oidc.ts
+++ b/src/runtime/types/oidc.ts
@@ -98,7 +98,7 @@ export interface OidcProviderConfig {
    * Token request type
    * @default 'form'
    */
-  tokenRequestType?: 'form' | 'json'
+  tokenRequestType?: 'form' | 'json' | 'form-urlencoded'
   /**
    * Audience used for token validation (not included in requests by default, use additionalTokenParameters or additionalAuthParameters to add it)
    */


### PR DESCRIPTION
These changes add `form-urlencoded` to the possible `tokenRequestType`s to allow token requests to use the `application/x-www-form-urlencoded` format/content-type.