### PR TITLE
fixed requestform data gen with URLSearchParams

### DIFF
--- a/src/runtime/server/lib/oidc.ts
+++ b/src/runtime/server/lib/oidc.ts
@@ -6,7 +6,7 @@ import { useRuntimeConfig, useStorage } from '#imports'
 import { validateConfig } from '../utils/config'
 import { generateRandomUrlSafeString, generatePkceVerifier, generatePkceCodeChallenge, parseJwtToken, encryptToken, validateToken, genBase64FromString } from '../utils/security'
 import { getUserSessionId, clearUserSession } from '../utils/session'
-import { configMerger, convertObjectToSnakeCase, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
+import { configMerger, convertObjectToSnakeCase, generateFormDataRequest, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
 import { SignJWT } from 'jose'
 import * as providerPresets from '../../providers'
 import type { H3Event } from 'h3'
@@ -147,14 +147,7 @@ export function callbackEventHandler({ onSuccess, onError }: OAuthConfig<UserSes
       ...config.additionalTokenParameters && convertObjectToSnakeCase(config.additionalTokenParameters),
     }
 
-    // const requestForm = generateFormDataRequest(requestBody)
-
-    const requestForm = new URLSearchParams()
-    for (const [key, value] of Object.entries(requestBody)) {
-      if (value !== undefined) {
-        requestForm.append(key, value)
-      }
-    }
+    const requestForm = generateFormDataRequest(requestBody)
 
     // Make token request
     let tokenResponse: TokenRespose

--- a/src/runtime/server/lib/oidc.ts
+++ b/src/runtime/server/lib/oidc.ts
@@ -6,7 +6,7 @@ import { useRuntimeConfig, useStorage } from '#imports'
 import { validateConfig } from '../utils/config'
 import { generateRandomUrlSafeString, generatePkceVerifier, generatePkceCodeChallenge, parseJwtToken, encryptToken, validateToken, genBase64FromString } from '../utils/security'
 import { getUserSessionId, clearUserSession } from '../utils/session'
-import { configMerger, convertObjectToSnakeCase, generateFormDataRequest, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
+import { configMerger, convertObjectToSnakeCase, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
 import { SignJWT } from 'jose'
 import * as providerPresets from '../../providers'
 import type { H3Event } from 'h3'
@@ -147,7 +147,14 @@ export function callbackEventHandler({ onSuccess, onError }: OAuthConfig<UserSes
       ...config.additionalTokenParameters && convertObjectToSnakeCase(config.additionalTokenParameters),
     }
 
-    const requestForm = generateFormDataRequest(requestBody)
+    // const requestForm = generateFormDataRequest(requestBody)
+
+    const requestForm = new URLSearchParams()
+    for (const [key, value] of Object.entries(requestBody)) {
+      if (value !== undefined) {
+        requestForm.append(key, value)
+      }
+    }
 
     // Make token request
     let tokenResponse: TokenRespose

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -40,13 +40,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     ...(config.scopeInTokenRequest && config.scope) && { scope: config.scope.join(' ') },
     ...(config.authenticationScheme === 'body') && { client_secret: normalizeURL(config.clientSecret) }
   }
-  // const requestForm = generateFormDataRequest(requestBody)
-  const requestForm = new URLSearchParams()
-    for (const [key, value] of Object.entries(requestBody)) {
-      if (value !== undefined) {
-        requestForm.append(key, value)
-      }
-    }
+  const requestForm = generateFormDataRequest(requestBody)
 
   // Make refresh token request
   let tokenResponse: TokenRespose
@@ -99,10 +93,12 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
 }
 
 export function generateFormDataRequest(requestValues: RefreshTokenRequest | TokenRequest) {
-  const requestBody = new FormData()
-  Object.keys(requestValues).forEach((key) => {
-    requestBody.append(key, normalizeURL(requestValues[(key as keyof typeof requestValues)] as string))
-  })
+  const requestBody = new URLSearchParams()
+  for (const [key, value] of Object.entries(requestValues)) {
+    if (value !== undefined) {
+      requestBody.append(key, value)
+    }
+  }
   return requestBody
 }
 

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -40,7 +40,13 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     ...(config.scopeInTokenRequest && config.scope) && { scope: config.scope.join(' ') },
     ...(config.authenticationScheme === 'body') && { client_secret: normalizeURL(config.clientSecret) }
   }
-  const requestForm = generateFormDataRequest(requestBody)
+  // const requestForm = generateFormDataRequest(requestBody)
+  const requestForm = new URLSearchParams()
+    for (const [key, value] of Object.entries(requestBody)) {
+      if (value !== undefined) {
+        requestForm.append(key, value)
+      }
+    }
 
   // Make refresh token request
   let tokenResponse: TokenRespose


### PR DESCRIPTION
Using URLSearchParams() instead of FormData() makes it compatible with older versions of keycloak...