### PR TITLE
fix: access token too big for h3 session

### DIFF
--- a/src/runtime/server/lib/oidc.ts
+++ b/src/runtime/server/lib/oidc.ts
@@ -233,10 +233,6 @@ export function callbackEventHandler({ onSuccess, onError }: OAuthConfig<UserSes
       config.optionalClaims.forEach(claim => parsedIdToken[claim] && ((user.claims as Record<string, unknown>)[claim] = (parsedIdToken[claim])))
     }
 
-    // Expose access token
-    if (config.exposeAccessToken)
-      user.accessToken = tokenResponse.access_token
-
     if (config.exposeIdToken)
       user.idToken = tokenResponse.id_token
 

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -77,10 +77,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     config.optionalClaims.forEach(claim => parsedIdToken[claim] && ((user.claims as Record<string, unknown>)[claim] = (parsedIdToken[claim])))
   }
 
-  // Expose tokens
-  if (config.exposeAccessToken)
-    user.accessToken = tokenResponse.access_token
-
+  // Expose id token
   if (config.exposeIdToken)
     user.idToken = tokenResponse.id_token
 


### PR DESCRIPTION
Fixes the problem from issue #20 that the access token becomes too large for the h3 session and thus creates a login loop.