### PR TITLE
fix(session): 🐛 Remove 'removeMeta' while removing an item from storage

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -52,7 +52,7 @@ export async function clearUserSession(event: H3Event) {
 
   await sessionHooks.callHookParallel('clear', session.data, event)
 
-  await useStorage('oidc').removeItem(session.id as string, { removeMeta: true })
+  await useStorage('oidc').removeItem(session.id as string)
   await session.clear()
   deleteCookie(event, sessionName)
 


### PR DESCRIPTION
Setting the `removeMeta` option is throwing a 404 for some unstorage drivers like Azure storage table as an additional `removeItem()` call is made for the non-existent metadata item. These 404 exceptions are not handled and causes the logout to fail.

Since the `setMeta()` does not appear to be used in this module, we can safely remove the `removeMeta` option without any loss in functionality.

This is a fix for the issue described in #47.