### PR TITLE
add client_id to logoutEventHandler redirect

### DIFF
--- a/src/runtime/server/lib/oidc.ts
+++ b/src/runtime/server/lib/oidc.ts
@@ -278,7 +278,7 @@ export function logoutEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
     if (config.logoutUrl) {
       return sendRedirect(
         event,
-        withQuery(config.logoutUrl, { ...config.logoutRedirectParameterName && { [config.logoutRedirectParameterName]: `${getRequestURL(event).protocol}//${getRequestURL(event).host}` } }),
+        withQuery(config.logoutUrl, { ...config.logoutRedirectParameterName && { [config.logoutRedirectParameterName]: `${getRequestURL(event).protocol}//${getRequestURL(event).host}`, client_id: config.clientId } }),
         200,
       )
     }


### PR DESCRIPTION
Still requires to click a second logout button in Keycloak, but at least now the redirect works.
Relates to #40