### PR TITLE
Add id token to sessions even if expired

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -158,6 +158,12 @@ export async function getUserSession(event: H3Event) {
       // Automatic token refresh
       if (providerSessionConfigs[provider].automaticRefresh) {
         await refreshUserSession(event)
+        if (useRuntimeConfig(event).oidc.providers[provider]?.exposeAccessToken || providerPresets[provider].exposeAccessToken) {
+          const persistentSession = await useStorage('oidc').getItem<PersistentSession>(session.id as string) as PersistentSession | null
+          const tokenKey = process.env.NUXT_OIDC_TOKEN_KEY as string
+          if (persistentSession)
+            userSession.accessToken = await decryptToken(persistentSession.accessToken, tokenKey)
+        }
         return userSession
       }
       await clearUserSession(event)


### PR DESCRIPTION
Fixes #79, logout without confirm screen fails due to missing id_token_hint