### PR TITLE
fix(zitadel): correcting provider for the playground

### DIFF
--- a/playground/composables/useProviders.ts
+++ b/playground/composables/useProviders.ts
@@ -41,7 +41,7 @@ export function useProviders(currentProvider: string) {
     {
       label: 'Zitadel',
       name: 'zitadel',
-      disabled: Boolean(currentProvider === 'cognito'),
+      disabled: Boolean(currentProvider === 'zitadel'),
       icon: 'i-majesticons-puzzle',
     },
     {


### PR DESCRIPTION
The provider name in the playground is not correct for zitadel