### PR TITLE
fix(auth0): Skip parse access token

### DIFF
--- a/src/runtime/providers/auth0.ts
+++ b/src/runtime/providers/auth0.ts
@@ -55,6 +55,7 @@ export const auth0 = defineOidcProvider<Auth0ProviderConfig, Auth0RequiredFields
     const baseUrl = normalizeURL(withoutTrailingSlash(withHttps(config.baseUrl as string)))
     return await ofetch(`${baseUrl}/.well-known/openid-configuration`)
   },
-  validateAccessToken: true,
+  validateAccessToken: false,
+  skipAccessTokenParsing: true,
   validateIdToken: false,
 })


### PR DESCRIPTION
## Description
Thank you for the convenient module! 
I am currently trying to integrate Auth0 into Nuxt.js (SSR) using this module.

After creating an Auth0 application and setting up the nuxt.config.ts and .env files, I ran the Nuxt.js app and encountered an `Invalid JWT token` error.

To investigate further, I added console.log statements within the nuxt-oidc-auth code and discovered that the access token returned from Auth0's token endpoint (/oauth/token) is encrypted, resulting in an empty payload part.

![image](https://github.com/user-attachments/assets/59bf551b-e01e-4014-8187-e1e079648b71)


From my attempts, I found that specifying `skipAccessTokenParsing: true` and `validateAccessToken: false` was necessary to bypass this issue, which is why I created this PR.

I apologize for the inconvenience, but I would appreciate it if you could review it.

## Setps to reproduce
Minimal reproduction code is https://github.com/tri-star/nuxt-oidc-auth-test .

- Auth0 application settings
  - Application type: Regular application
  - Advanced settings / Grant types: Authorization code, Refresh token
  - Connections: GitHub, google-oauth2
