### PR TITLE
feature: add env-var to allow users to rename the token

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -9,7 +9,7 @@ import * as providerPresets from '../../providers'
 import { configMerger, oidcErrorHandler, refreshAccessToken, useOidcLogger } from './oidc'
 import { decryptToken, encryptToken } from './security'
 
-const sessionName = 'nuxt-oidc-auth'
+const sessionName = process.env.NUXT_OIDC_AUTH_SESSION_COOKIE_NAME as string | 'nuxt-oidc-auth'
 let sessionConfig: Pick<SessionConfig, 'name' | 'password'> & AuthSessionConfig
 const providerSessionConfigs: Record<ProviderKeys, ProviderSessionConfig> = {} as any
 


### PR DESCRIPTION
closes #75 
This pull request includes a change to the `src/runtime/server/utils/session.ts` file to make the session cookie name configurable through an environment variable.

Configuration changes:

* [`src/runtime/server/utils/session.ts`](diffhunk://#diff-924ff08bed63f380edb066147815aa363d2115f9b770185d9ba7c01dbd327a1aL12-R12): Modified the `sessionName` constant to use the value of the `NUXT_OIDC_AUTH_SESSION_COOKIE_NAME` environment variable if it is set, otherwise defaulting to `'nuxt-oidc-auth'`.