### PR TITLE
fix: Improve handling of UserSession data on login and refresh

### DIFF
--- a/src/runtime/plugins/oidcInit.ts
+++ b/src/runtime/plugins/oidcInit.ts
@@ -1,0 +1,62 @@
+import type { NitroApp } from 'nitropack/types'
+import type { OidcProviderConfig } from '../server/utils/provider'
+import type { ProviderConfigs, ProviderURLConfigSet } from '../types'
+import { defineNitroPlugin } from 'nitropack/dist/runtime/plugin'
+import { useRuntimeConfig } from 'nitropack/runtime'
+import * as providerPresets from '../providers'
+import { generateProviderUrl, replaceInjectedParameters } from '../server/utils/config'
+
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  const providerUrls: ProviderURLConfigSet = {}
+
+  const config = useRuntimeConfig()
+  const providers = config.oidc.providers as ProviderConfigs
+  const providerIds = Object.keys(config.oidc.providers)
+
+  providerIds.forEach((pidKey) => {
+    const pid = pidKey as keyof ProviderConfigs
+    const provider = providers[pid] as Record<string, any>
+    if (!provider) {
+      return
+    }
+
+    const presets = providerPresets[pid]
+
+    // const baseUrl: string = process.env[`NUXT_OIDC_PROVIDERS_${pid.toUpperCase()}_BASE_URL`]
+    const baseUrl: string = config.oidc.providers[pid]?.baseUrl
+      || provider.baseUrl
+      || presets.baseUrl
+
+    // Generate provider routes
+    if (baseUrl) {
+      let _baseUrl = baseUrl
+      const placeholders = baseUrl.matchAll(/\{(.*?)\}/g)
+      for (const placeholderMatch of placeholders) {
+        if (placeholderMatch && provider && placeholderMatch[1] in provider) {
+          _baseUrl = _baseUrl.replace(`{${placeholderMatch[1]}}`, provider[placeholderMatch[1]])
+        }
+      }
+
+      providerUrls[pid] = {
+        authorizationUrl: generateProviderUrl(_baseUrl, presets.authorizationUrl),
+        tokenUrl: generateProviderUrl(_baseUrl, presets.tokenUrl),
+        userInfoUrl: presets.userInfoUrl
+          ? presets.userInfoUrl.startsWith('https') ? presets.userInfoUrl : generateProviderUrl(_baseUrl, presets.userInfoUrl)
+          : undefined,
+        logoutUrl: presets.logoutUrl ? generateProviderUrl(_baseUrl, presets.logoutUrl) : undefined,
+      }
+    }
+    else {
+      providerUrls[pid] = {
+        authorizationUrl: presets.authorizationUrl || '',
+        tokenUrl: presets.tokenUrl || '',
+        userInfoUrl: presets.userInfoUrl,
+        logoutUrl: presets.logoutUrl,
+      }
+    }
+  })
+
+  nitroApp.hooks.hook('request', (event) => {
+    event.context.providerUrls = providerUrls
+  })
+})

--- a/src/runtime/server/handler/login.get.ts
+++ b/src/runtime/server/handler/login.get.ts
@@ -8,7 +8,7 @@ import * as providerPresets from '../../providers'
 import { validateConfig } from '../utils/config'
 import { configMerger, convertObjectToSnakeCase, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
 import { generatePkceCodeChallenge, generatePkceVerifier, generateRandomUrlSafeString } from '../utils/security'
-import { useAuthSession } from '../utils/session'
+import { clearUserSession, useAuthSession } from '../utils/session'
 
 function loginEventHandler() {
   const logger = useOidcLogger()
@@ -21,6 +21,10 @@ function loginEventHandler() {
       logger.error(`[${provider}] Missing configuration properties:`, validationResult.missingProperties?.join(', '))
       oidcErrorHandler(event, 'Invalid configuration')
     }
+
+    // If a login is beginning, purge the user session,
+    // as it may contain OIDC claims from a previous login
+    await clearUserSession(event)
 
     // Initialize auth session
     const session = await useAuthSession(event, config.sessionConfiguration?.maxAuthSessionAge)

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -22,7 +22,7 @@ export const configMerger = createDefu((obj, key, value) => {
   }
 })
 
-export async function refreshAccessToken(refreshToken: string, config: OidcProviderConfig) {
+export async function refreshAccessToken(refreshToken: string, config: OidcProviderConfig, tokenUrl: string) {
   const logger = useOidcLogger()
   const customFetch = await createProviderFetch(config)
   // Construct request header object
@@ -46,7 +46,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
   let tokenResponse: TokenRespose
   try {
     tokenResponse = await customFetch(
-      config.tokenUrl,
+      tokenUrl,
       {
         method: 'POST',
         headers,

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -1,12 +1,5 @@
 import type { H3Event, SessionConfig } from 'h3'
-import type {
-  AuthSession,
-  AuthSessionConfig,
-  PersistentSession,
-  ProviderKeys,
-  ProviderSessionConfig,
-  UserSession,
-} from '../../types'
+import type { AuthSession, AuthSessionConfig, PersistentSession, ProviderKeys, ProviderSessionConfig, UserSession } from '../../types'
 import type { OidcProviderConfig } from './provider'
 import { useRuntimeConfig, useStorage } from '#imports'
 import { defu } from 'defu'

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -5,8 +5,41 @@ import type * as _PROVIDERS from './providers'
 
 import type { EncryptedToken, JwtPayload } from './server/utils/security'
 
-export type ProviderKeys = 'apple' | 'auth0' | 'entra' | 'github' | 'keycloak' | 'oidc' | 'cognito' | 'zitadel' | 'paypal' | 'microsoft' | 'logto'
+export type ProviderKeys =
+  'apple'
+  | 'auth0'
+  | 'entra'
+  | 'github'
+  | 'keycloak'
+  | 'oidc'
+  | 'cognito'
+  | 'zitadel'
+  | 'paypal'
+  | 'microsoft'
+  | 'logto'
 export type ProviderKeysWithDev = ProviderKeys | 'dev'
+export const PROVIDER_KEYS: ProviderKeysWithDev[] = [
+  'apple',
+  'auth0',
+  'entra',
+  'github',
+  'keycloak',
+  'oidc',
+  'cognito',
+  'zitadel',
+  'paypal',
+  'microsoft',
+  'logto',
+  'dev',
+]
+
+export interface ProviderURLConfig {
+  authorizationUrl: string
+  tokenUrl: string
+  logoutUrl?: string
+  userInfoUrl?: string
+}
+export type ProviderURLConfigSet = Partial<Record<ProviderKeysWithDev, ProviderURLConfig>>
 
 export interface ProviderConfigs {
   auth0: typeof _PROVIDERS.auth0
@@ -25,7 +58,7 @@ export interface ProviderConfigs {
 export interface OAuthConfig<UserSession> {
   onSuccess: (
     event: H3Event,
-    result: { user: UserSession | null; callbackRedirectUrl?: string }
+    result: { user: UserSession | null; callbackRedirectUrl?: string },
   ) => Promise<void> | void
 }
 
@@ -259,4 +292,5 @@ export interface AuthSessionConfig {
   singleSignOutIdField?: 'aud' | 'sub'
 }
 
-export interface ProviderSessionConfig extends Omit<AuthSessionConfig, 'maxAge' | 'cookie'> {}
+export interface ProviderSessionConfig extends Omit<AuthSessionConfig, 'maxAge' | 'cookie'> {
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -183,6 +183,23 @@ export interface UserSession {
   idToken?: string
 }
 
+// This is used elsewhere when iterating over keys of what should be a UserSession
+// object to avoid handling other data that may have been added at runtime.
+export type UserSessionKeys = ReadonlyArray<keyof UserSession>
+export const USER_SESSION_KEYS: UserSessionKeys = [
+  'provider',
+  'canRefresh',
+  'expireAt',
+  'singleSignOut',
+  'loggedInAt',
+  'updatedAt',
+  'userInfo',
+  'userName',
+  'claims',
+  'accessToken',
+  'idToken',
+]
+
 export interface Tokens {
   accessToken: JwtPayload
   idToken?: JwtPayload


### PR DESCRIPTION
Fixes #127

User sessions should be cleared in the login flow because there may not have been an explicit logout action to do this.

Replace use of defu() with a more explicit copy of UserSession data from the refreshed token into the session.