### PR TITLE
feat(login) Redirect after login

### DIFF
--- a/src/runtime/server/handler/login.get.ts
+++ b/src/runtime/server/handler/login.get.ts
@@ -25,13 +25,6 @@ function loginEventHandler() {
     // Initialize auth session
     const session = await useAuthSession(event, config.sessionConfiguration?.maxAuthSessionAge)
     await session.clear()
-    await session.update({
-      state: generateRandomUrlSafeString(),
-      codeVerifier: generatePkceVerifier(),
-      referer: getRequestHeader(event, 'referer'),
-      nonce: undefined,
-    })
-
     // Get client side query parameters
     const additionalClientAuthParameters: Record<string, string> = {}
     if (config.allowedClientAuthParameters?.length) {
@@ -42,6 +35,18 @@ function loginEventHandler() {
         }
       })
     }
+
+    const state = {
+      token: generateRandomUrlSafeString(),
+      additionalClientAuthParameters: additionalClientAuthParameters
+    }
+
+    await session.update({
+      state,
+      codeVerifier: generatePkceVerifier(),
+      referer: getRequestHeader(event, 'referer'),
+      nonce: undefined,
+    })
 
     let clientRedirectUri: string | undefined
     if (config.allowedCallbackRedirectUrls?.length) {


### PR DESCRIPTION
closes https://github.com/itpropro/nuxt-oidc-auth/issues/74
This pull request includes changes to the login and callback behaviour. Before this a random number was persisted as state and checked on callback. As I understood during Authorization Code Flow the state should be used to transport all data you need. So with this change we save all additionalClientAuthParameters to the state. On callback success the redirectUriOverride parameter is checked and you get redirected if its set. For this to work state must be enabled and redirectUriOverride  must be an allowed Parameter.
