### PR TITLE
fix: try using userNameClaim from userInfo when token is not a JWT

### DIFF
--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -183,9 +183,13 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       logger.warn(`[${provider}] Failed to fetch userinfo`, error)
     }
 
-    // Get user name from access token
+    // Get user name from access token or userInfo
     if (config.userNameClaim) {
-      user.userName = (config.userNameClaim in tokens.accessToken) ? tokens.accessToken[config.userNameClaim] as string : ''
+      user.userName
+        = (tokens.accessToken?.[config.userNameClaim] as string)
+          || (tokens.idToken?.[config.userNameClaim] as string)
+          || (user.userInfo?.[config.userNameClaim] as string)
+          || ''
     }
 
     // Get optional claims from id token


### PR DESCRIPTION
I had a problem of the `user.userName` being undefined even when I had set the `config.userNameClaim`. This was due to my access tokens being opaque and require fetching data from the userinfo endpoint.

I think some bigger changes could be made to improve the typescript types and the callback handler in general relating to opaque tokens, but this fix should be enough for now.