### PR TITLE
fix: harden dev mode env guard

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -151,7 +151,7 @@ export {}
       options.defaultProvider = providers[0]
     }
 
-    const isNonProductionEnvironment = process.env.NODE_ENV !== 'production'
+    const isNonProductionEnvironment = process.env.NODE_ENV && !process.env.NODE_ENV.toLowerCase().startsWith('prod')
 
     if (options.devMode?.enabled && !isNonProductionEnvironment) {
       logger.warn('Dev mode is enabled in config but will be ignored in production.')


### PR DESCRIPTION
### Motivation
- Restore a safe production guard because a prior change replaced a case-insensitive `prod*` check with an exact `'production'` comparison, which could enable dev-mode routes (including `/auth/dev/login`) in prod-like or unset `NODE_ENV` and allow creation of authenticated sessions without an OIDC flow.

### Description
- Replaced `const isNonProductionEnvironment = process.env.NODE_ENV !== 'production'` with `const isNonProductionEnvironment = process.env.NODE_ENV && !process.env.NODE_ENV.toLowerCase().startsWith('prod')` in `src/module.ts` to treat unset `NODE_ENV` and values starting with `prod` (case-insensitive) as production and prevent registration of dev-mode handlers and redirects.

### Testing
- Ran `pnpm test:unit`, which could not complete in this environment because `./.nuxt/tsconfig.json` is missing (project prepare step not run), so unit tests are not fully validated here; the change is a single-line logic fix in `src/module.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb817c35c832e9991947e769d9480)