### PR TITLE
fix(auth): prevent client-supplied auth params from overriding reserved OIDC fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## Unreleased
+
+### 🩹 Fixes
+
+- **auth:** Prevent client overrides of reserved OAuth/OIDC authorization parameters
+
 ## v1.0.0-beta.11
 
 [compare changes](https://github.com/itpropro/nuxt-oidc-auth/compare/v1.0.0-beta.10...v1.0.0-beta.11)

--- a/src/runtime/server/handler/login.get.ts
+++ b/src/runtime/server/handler/login.get.ts
@@ -20,6 +20,19 @@ import {
 } from '../utils/security'
 import { useAuthSession } from '../utils/session'
 
+const reservedAuthParameters = new Set([
+  'clientId',
+  'responseType',
+  'state',
+  'scope',
+  'responseMode',
+  'redirectUri',
+  'prompt',
+  'codeChallenge',
+  'codeChallengeMethod',
+  'nonce',
+])
+
 function loginEventHandler() {
   const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
@@ -53,6 +66,9 @@ function loginEventHandler() {
     const additionalClientAuthParameters: Record<string, string> = {}
     if (config.allowedClientAuthParameters?.length) {
       config.allowedClientAuthParameters.forEach((param) => {
+        if (reservedAuthParameters.has(param)) {
+          return
+        }
         if (clientQueryParams[param]) {
           additionalClientAuthParameters[param] = clientQueryParams[param] as string
         }

--- a/src/runtime/server/handler/login.get.ts
+++ b/src/runtime/server/handler/login.get.ts
@@ -14,17 +14,18 @@ import {
   generateRandomUrlSafeString,
 } from '../utils/security'
 import { useAuthSession } from '../utils/session'
+import { snakeCase } from '../utils/string'
 
 const reservedAuthParameters = new Set([
-  'clientId',
-  'responseType',
+  'client_id',
+  'redirect_uri',
+  'response_type',
+  'response_mode',
   'state',
   'scope',
-  'responseMode',
-  'redirectUri',
   'prompt',
-  'codeChallenge',
-  'codeChallengeMethod',
+  'code_challenge',
+  'code_challenge_method',
   'nonce',
 ])
 
@@ -61,7 +62,7 @@ function loginEventHandler() {
     const additionalClientAuthParameters: Record<string, string> = {}
     if (config.allowedClientAuthParameters?.length) {
       config.allowedClientAuthParameters.forEach((param) => {
-        if (reservedAuthParameters.has(param)) {
+        if (reservedAuthParameters.has(snakeCase(param))) {
           return
         }
         if (clientQueryParams[param]) {

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -195,6 +195,7 @@ export interface OidcProviderConfig {
   allowedCallbackRedirectUrls?: string[]
   /**
    * List of allowed client-side user-added query parameters for the auth request
+   * Reserved OAuth/OIDC parameters are always blocked
    * @default []
    */
   allowedClientAuthParameters?: string[]

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -195,7 +195,7 @@ export interface OidcProviderConfig {
   allowedCallbackRedirectUrls?: string[]
   /**
    * List of allowed client-side user-added query parameters for the auth request
-   * Reserved OAuth/OIDC parameters are server-controlled and cannot be overridden
+   * Reserved OAuth/OIDC parameters cannot be overridden through this allowlist
    * @default []
    */
   allowedClientAuthParameters?: string[]

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -195,7 +195,7 @@ export interface OidcProviderConfig {
   allowedCallbackRedirectUrls?: string[]
   /**
    * List of allowed client-side user-added query parameters for the auth request
-   * Reserved OAuth/OIDC parameters are always blocked
+   * Reserved OAuth/OIDC parameters are server-controlled and cannot be overridden
    * @default []
    */
   allowedClientAuthParameters?: string[]

--- a/test/functional/login.test.ts
+++ b/test/functional/login.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { HandlerHarness } from './handler-harness'
+
+const providerConfig = {
+  clientId: 'functional-client',
+  clientSecret: 'functional-secret',
+  authorizationUrl: 'https://identity.example.test/authorize',
+  tokenUrl: 'https://identity.example.test/token',
+  redirectUri: 'https://app.example.test/auth/oidc/callback',
+  requiredProperties: ['clientId', 'clientSecret', 'authorizationUrl', 'tokenUrl', 'redirectUri'],
+}
+
+describe('login handler', () => {
+  it.each(['redirectUri', 'redirect_uri'])(
+    'keeps reserved %s server-controlled while forwarding safe parameters',
+    async (reservedParameter) => {
+      const harness = new HandlerHarness({
+        runtimeConfig: {
+          oidc: {
+            providers: {
+              oidc: {
+                ...providerConfig,
+                allowedClientAuthParameters: [reservedParameter, 'customParameter'],
+              },
+            },
+          },
+        },
+      })
+      const loginHandler = (await import('../../src/runtime/server/handler/login.get')).default
+      const request = harness.createEvent({
+        path: '/auth/oidc/login',
+        query: {
+          [reservedParameter]: 'https://attacker.example.test/callback',
+          customParameter: 'preserved-value',
+        },
+      })
+
+      await loginHandler(request.event)
+
+      const authorizationUrl = new URL(request.response.location!)
+      expect(request.response.status).toBe(302)
+      expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(providerConfig.redirectUri)
+      expect(authorizationUrl.searchParams.get('custom_parameter')).toBe('preserved-value')
+      expect(request.response.location).not.toContain('attacker.example.test')
+    },
+  )
+})

--- a/test/functional/login.test.ts
+++ b/test/functional/login.test.ts
@@ -7,20 +7,55 @@ const providerConfig = {
   authorizationUrl: 'https://identity.example.test/authorize',
   tokenUrl: 'https://identity.example.test/token',
   redirectUri: 'https://app.example.test/auth/oidc/callback',
+  responseType: 'code',
+  pkce: true,
+  state: true,
+  nonce: true,
+  scope: ['openid', 'profile'],
   requiredProperties: ['clientId', 'clientSecret', 'authorizationUrl', 'tokenUrl', 'redirectUri'],
 }
 
+const attackerValue = 'attacker-controlled-value'
+const customParameter = 'customProviderParameter'
+const customValue = 'preserved-value'
+const overrideCases = [
+  {
+    style: 'camelCase',
+    parameters: [
+      'redirectUri',
+      'clientId',
+      'responseType',
+      'codeChallenge',
+      'state',
+      'scope',
+      'nonce',
+    ],
+  },
+  {
+    style: 'snake_case',
+    parameters: [
+      'redirect_uri',
+      'client_id',
+      'response_type',
+      'code_challenge',
+      'state',
+      'scope',
+      'nonce',
+    ],
+  },
+]
+
 describe('login handler', () => {
-  it.each(['redirectUri', 'redirect_uri'])(
-    'keeps reserved %s server-controlled while forwarding safe parameters',
-    async (reservedParameter) => {
+  it.each(overrideCases)(
+    'keeps $style reserved authorization parameters server-controlled',
+    async ({ parameters }) => {
       const harness = new HandlerHarness({
         runtimeConfig: {
           oidc: {
             providers: {
               oidc: {
                 ...providerConfig,
-                allowedClientAuthParameters: [reservedParameter, 'customParameter'],
+                allowedClientAuthParameters: [...parameters, customParameter],
               },
             },
           },
@@ -30,18 +65,34 @@ describe('login handler', () => {
       const request = harness.createEvent({
         path: '/auth/oidc/login',
         query: {
-          [reservedParameter]: 'https://attacker.example.test/callback',
-          customParameter: 'preserved-value',
+          ...Object.fromEntries(parameters.map((parameter) => [parameter, attackerValue])),
+          [customParameter]: customValue,
         },
       })
 
       await loginHandler(request.event)
 
-      const authorizationUrl = new URL(request.response.location!)
+      const location = request.response.location
+      expect(location).toBeDefined()
+      if (!location) throw new Error('Login handler did not return a redirect Location')
+
+      const authorizationUrl = new URL(location)
+      const authSession = harness.inspectSession('oidc')
       expect(request.response.status).toBe(302)
+      expect(authorizationUrl.searchParams.get('client_id')).toBe(providerConfig.clientId)
       expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(providerConfig.redirectUri)
-      expect(authorizationUrl.searchParams.get('custom_parameter')).toBe('preserved-value')
-      expect(request.response.location).not.toContain('attacker.example.test')
+      expect(authorizationUrl.searchParams.get('response_type')).toBe(providerConfig.responseType)
+      expect(authorizationUrl.searchParams.get('scope')).toBe(providerConfig.scope.join(' '))
+      expect(authorizationUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
+      expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256')
+      expect(authSession?.data).toMatchObject({
+        state: expect.any(String),
+        nonce: expect.any(String),
+      })
+      expect(authorizationUrl.searchParams.get('state')).toBe(authSession?.data.state)
+      expect(authorizationUrl.searchParams.get('nonce')).toBe(authSession?.data.nonce)
+      expect(authorizationUrl.searchParams.get('custom_provider_parameter')).toBe(customValue)
+      expect(location).not.toContain(attackerValue)
     },
   )
 })

--- a/test/functional/login.test.ts
+++ b/test/functional/login.test.ts
@@ -8,6 +8,7 @@ const providerConfig = {
   tokenUrl: 'https://identity.example.test/token',
   redirectUri: 'https://app.example.test/auth/oidc/callback',
   responseType: 'code',
+  prompt: ['login'],
   pkce: true,
   state: true,
   nonce: true,
@@ -25,7 +26,10 @@ const overrideCases = [
       'redirectUri',
       'clientId',
       'responseType',
+      'responseMode',
+      'prompt',
       'codeChallenge',
+      'codeChallengeMethod',
       'state',
       'scope',
       'nonce',
@@ -37,7 +41,10 @@ const overrideCases = [
       'redirect_uri',
       'client_id',
       'response_type',
+      'response_mode',
+      'prompt',
       'code_challenge',
+      'code_challenge_method',
       'state',
       'scope',
       'nonce',
@@ -82,6 +89,8 @@ describe('login handler', () => {
       expect(authorizationUrl.searchParams.get('client_id')).toBe(providerConfig.clientId)
       expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(providerConfig.redirectUri)
       expect(authorizationUrl.searchParams.get('response_type')).toBe(providerConfig.responseType)
+      expect(authorizationUrl.searchParams.get('response_mode')).toBe('form_post')
+      expect(authorizationUrl.searchParams.get('prompt')).toBe(providerConfig.prompt.join(' '))
       expect(authorizationUrl.searchParams.get('scope')).toBe(providerConfig.scope.join(' '))
       expect(authorizationUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
       expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256')

--- a/test/functional/login.test.ts
+++ b/test/functional/login.test.ts
@@ -8,10 +8,11 @@ const providerConfig = {
   tokenUrl: 'https://identity.example.test/token',
   redirectUri: 'https://app.example.test/auth/oidc/callback',
   responseType: 'code',
+  responseMode: 'query',
   prompt: ['login'],
   pkce: true,
   state: true,
-  nonce: true,
+  nonce: false,
   scope: ['openid', 'profile'],
   requiredProperties: ['clientId', 'clientSecret', 'authorizationUrl', 'tokenUrl', 'redirectUri'],
 }
@@ -89,17 +90,16 @@ describe('login handler', () => {
       expect(authorizationUrl.searchParams.get('client_id')).toBe(providerConfig.clientId)
       expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(providerConfig.redirectUri)
       expect(authorizationUrl.searchParams.get('response_type')).toBe(providerConfig.responseType)
-      expect(authorizationUrl.searchParams.get('response_mode')).toBe('form_post')
+      expect(authorizationUrl.searchParams.get('response_mode')).toBe(providerConfig.responseMode)
       expect(authorizationUrl.searchParams.get('prompt')).toBe(providerConfig.prompt.join(' '))
       expect(authorizationUrl.searchParams.get('scope')).toBe(providerConfig.scope.join(' '))
       expect(authorizationUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/)
       expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256')
       expect(authSession?.data).toMatchObject({
         state: expect.any(String),
-        nonce: expect.any(String),
       })
       expect(authorizationUrl.searchParams.get('state')).toBe(authSession?.data.state)
-      expect(authorizationUrl.searchParams.get('nonce')).toBe(authSession?.data.nonce)
+      expect(authorizationUrl.searchParams.has('nonce')).toBe(false)
       expect(authorizationUrl.searchParams.get('custom_provider_parameter')).toBe(customValue)
       expect(location).not.toContain(attackerValue)
     },


### PR DESCRIPTION
## Motivation

Client-supplied allowlisted authorization parameters could override server-controlled OAuth/OIDC fields after query normalization.

## Changes

- Canonicalize allowlisted parameter names before filtering.
- Block redirect URI, client ID, response type/mode, state, scope, prompt, PKCE challenge/method, and nonce overrides.
- Preserve forwarding for non-reserved custom provider parameters.
- Document reserved parameter behavior.
- Add behavior-first functional coverage for camelCase and snake_case exploit attempts.
- Add Unreleased changelog entry.

## Verification

- pnpm fmt:check
- pnpm lint: 0 errors; 24 existing warnings
- pnpm typecheck
- pnpm test:unit: 131 passed
- pnpm test:functional: 9 passed
- pnpm prepack
- pnpm test:e2e --workers=1: 32 passed; 32 provider-config-gated skipped
- GitHub CodeQL and Socket checks

Tracks #172 and #174.