### PR TITLE
fix(callback): preserve session redirect url before clearing auth session

### DIFF
--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -286,6 +286,7 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       await useStorage('oidc').setItem<PersistentSession>(userSessionId, persistentSession)
     }
 
+    const sessionCallbackRedirectUrl = session.data.callbackRedirectUrl
     await session.clear()
     deleteCookie(event, 'oidc')
     return onSuccess(event, {
@@ -293,7 +294,7 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       callbackRedirectUrl: resolveCallbackRedirectUrl({
         configuredCallbackRedirectUrl: config.callbackRedirectUrl,
         hasConfiguredCallbackRedirectUrl,
-        sessionCallbackRedirectUrl: session.data.callbackRedirectUrl,
+        sessionCallbackRedirectUrl,
       }),
     })
   })


### PR DESCRIPTION
## Summary

Fixes #159.
Fixes #149.

In `callbackEventHandler` (`src/runtime/server/handler/callback.ts`), `session.clear()` was called before reading `session.data.callbackRedirectUrl`, so the value passed to `resolveCallbackRedirectUrl` was always `undefined`. As a result, users were always redirected to `/` after sign-in, even when the global middleware had stored the original target path in the session via `?callbackRedirectUrl=...`.

## Fix

Capture `session.data.callbackRedirectUrl` into a local variable before clearing the session, then pass that local variable to `resolveCallbackRedirectUrl`. This matches the original intent of the helper and restores the expected behavior of the existing `middleware-callback-redirect` E2E flow.

```diff
+    const sessionCallbackRedirectUrl = session.data.callbackRedirectUrl
     await session.clear()
     deleteCookie(event, 'oidc')
     return onSuccess(event, {
       user,
       callbackRedirectUrl: resolveCallbackRedirectUrl({
         configuredCallbackRedirectUrl: config.callbackRedirectUrl,
         hasConfiguredCallbackRedirectUrl,
-        sessionCallbackRedirectUrl: session.data.callbackRedirectUrl,
+        sessionCallbackRedirectUrl,
       }),
     })
```

## Tests

- Existing unit tests on `resolveCallbackRedirectUrl` (`test/unit/utils/redirect.test.ts`) still pass.
- `pnpm test:unit` — 9 files, 121 tests passing.
- `pnpm typecheck` — clean.
- `pnpm lint` — no new errors/warnings introduced by this change.

I did not add a new test: a unit test on `resolveCallbackRedirectUrl` would not have caught this regression (the helper itself was already correct). A meaningful regression test would require either a heavily mocked handler test or a full E2E provider flow; happy to add one if you have a preferred approach.
