### PR TITLE
fix: resolve provider runtime configuration

### DIFF
--- a/docs/content/99.contributing.md
+++ b/docs/content/99.contributing.md
@@ -20,4 +20,7 @@ pnpm run dev:build
 
 # Run ESLint
 pnpm run lint
+
+# Run in-process functional handler tests
+pnpm test:functional
 ```

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "test:unit": "vitest run --config test/vitest.config.ts --root . test/unit/",
     "test:functional": "vitest run --config test/vitest.config.ts --root . test/functional/",
     "test:e2e": "playwright test --config playwright.config.ts",
-    "test:e2e:oidc": "playwright test --config playwright.config.ts --grep 'Generic OIDC'",
     "test:check-env": "npx tsx test/setup/env-validator.ts --check"
   },
   "dependencies": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -274,10 +274,8 @@ export {}
       })
     }
 
-    // Add single sign out middleware
-    if (
-      providers.some((provider) => options.providers[provider]?.sessionConfiguration?.singleSignOut)
-    ) {
+    if (providers.length > 0) {
+      // Runtime environment overrides are applied after module setup, so SSO support must be available.
       addPlugin(resolve('./runtime/plugins/sso.client'))
       addServerHandler({
         handler: resolve('./runtime/server/api/sso'),

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-import type { OidcProviderConfig } from './runtime/server/utils/provider'
 import type {
   AuthSessionConfig,
   DevModeConfig,
@@ -21,11 +20,10 @@ import {
 import { defu } from 'defu'
 import { setupDevToolsUI } from './devtools'
 import * as providerPresets from './runtime/providers'
-import { generateProviderUrl, replaceInjectedParameters } from './runtime/server/utils/config'
+import { createProviderRuntimeConfig } from './runtime/server/utils/config'
 
 // oxlint-disable-next-line typescript-eslint/unbound-method -- createResolver returns a standalone resolve function
 const { resolve } = createResolver(import.meta.url)
-const PLACEHOLDER_RE = /\{(.*?)\}/g
 
 const DEFAULTS: ModuleOptions = {
   enabled: true,
@@ -151,7 +149,8 @@ export {}
       options.defaultProvider = providers[0]
     }
 
-    const isNonProductionEnvironment = process.env.NODE_ENV && !process.env.NODE_ENV.toLowerCase().startsWith('prod')
+    const isNonProductionEnvironment =
+      process.env.NODE_ENV && !process.env.NODE_ENV.toLowerCase().startsWith('prod')
 
     if (options.devMode?.enabled && !isNonProductionEnvironment) {
       logger.warn('Dev mode is enabled in config but will be ignored in production.')
@@ -230,53 +229,12 @@ export {}
 
     // Per provider tasks
     providers.forEach((provider) => {
-      const providerConfig = options.providers[provider] as OidcProviderConfig
-      const baseUrl =
-        process.env[`NUXT_OIDC_PROVIDERS_${provider.toUpperCase()}_BASE_URL`] ||
-        providerConfig.baseUrl ||
-        providerPresets[provider].baseUrl
-
-      // Generate provider routes
-      if (baseUrl) {
-        let _baseUrl = baseUrl
-        const placeholders = baseUrl.matchAll(PLACEHOLDER_RE)
-        for (const placeholderMatch of placeholders) {
-          const placeholderKey = placeholderMatch[1]
-          if (!placeholderKey) {
-            continue
-          }
-          if (Object.hasOwn(providerConfig, placeholderKey)) {
-            const placeholderValue = providerConfig[placeholderKey as keyof OidcProviderConfig]
-            if (placeholderValue !== undefined && typeof placeholderValue !== 'object') {
-              _baseUrl = _baseUrl.replace(`{${placeholderKey}}`, String(placeholderValue))
-            }
-          }
-        }
-        providerConfig.authorizationUrl = generateProviderUrl(
-          _baseUrl as string,
-          providerPresets[provider].authorizationUrl,
-        )
-        providerConfig.tokenUrl = generateProviderUrl(
-          _baseUrl as string,
-          providerPresets[provider].tokenUrl,
-        )
-        if (
-          providerPresets[provider].userInfoUrl &&
-          !providerPresets[provider].userInfoUrl.startsWith('https')
-        )
-          providerConfig.userInfoUrl = generateProviderUrl(
-            _baseUrl as string,
-            providerPresets[provider].userInfoUrl,
-          )
-        if (providerPresets[provider].logoutUrl)
-          providerConfig.logoutUrl = generateProviderUrl(
-            _baseUrl as string,
-            providerPresets[provider].logoutUrl,
-          )
-      }
-
-      // Replace placeholder parameters from provider presets
-      replaceInjectedParameters(['clientId'], providerConfig, providerPresets[provider], provider)
+      Object.assign(options.providers, {
+        [provider]: createProviderRuntimeConfig(
+          options.providers[provider],
+          providerPresets[provider],
+        ),
+      })
 
       // Add login handler
       addServerHandler({

--- a/src/runtime/providers/keycloak.ts
+++ b/src/runtime/providers/keycloak.ts
@@ -36,7 +36,14 @@ export const keycloak = defineOidcProvider<KeycloakProviderConfig, KeycloakRequi
   pkce: true,
   state: false,
   nonce: true,
-  requiredProperties: ['clientId', 'clientSecret', 'authorizationUrl', 'tokenUrl', 'redirectUri'],
+  requiredProperties: [
+    'baseUrl',
+    'clientId',
+    'clientSecret',
+    'authorizationUrl',
+    'tokenUrl',
+    'redirectUri',
+  ],
   additionalLogoutParameters: {
     idTokenHint: '',
   },
@@ -52,7 +59,10 @@ export const keycloak = defineOidcProvider<KeycloakProviderConfig, KeycloakRequi
   logoutUrl: 'protocol/openid-connect/logout',
   logoutRedirectParameterName: 'post_logout_redirect_uri',
   async openIdConfiguration(config: OidcProviderConfig) {
-    const configUrl = generateProviderUrl(config.baseUrl as string, '.well-known/openid-configuration')
+    const configUrl = generateProviderUrl(
+      config.baseUrl as string,
+      '.well-known/openid-configuration',
+    )
     const customFetch = await createProviderFetch(config)
     return await customFetch(configUrl)
   },

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -15,7 +15,11 @@ import { deleteCookie, eventHandler, getQuery, getRequestURL, readBody, sendRedi
 import { useStorage } from 'nitropack/runtime'
 import { normalizeURL, parseURL } from 'ufo'
 import * as providerPresets from '../../providers'
-import { resolveProviderConfig, validateProviderConfig } from '../utils/config'
+import {
+  hasExplicitProviderConfig,
+  resolveProviderConfig,
+  validateProviderConfig,
+} from '../utils/config'
 import { textToBase64 } from '../utils/encoding'
 import {
   convertObjectToSnakeCase,
@@ -34,8 +38,10 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
     const provider = event.path.split('/')[2] as ProviderKeys
     const runtimeProviderConfig = useRuntimeConfig().oidc.providers[provider] as OidcProviderConfig
     const config = resolveProviderConfig(runtimeProviderConfig, providerPresets[provider])
-    const hasConfiguredCallbackRedirectUrl =
-      typeof runtimeProviderConfig?.callbackRedirectUrl === 'string'
+    const hasConfiguredCallbackRedirectUrl = hasExplicitProviderConfig(
+      runtimeProviderConfig,
+      'callbackRedirectUrl',
+    )
 
     const validationResult = validateProviderConfig(config)
 

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -15,10 +15,9 @@ import { deleteCookie, eventHandler, getQuery, getRequestURL, readBody, sendRedi
 import { useStorage } from 'nitropack/runtime'
 import { normalizeURL, parseURL } from 'ufo'
 import * as providerPresets from '../../providers'
-import { validateConfig } from '../utils/config'
+import { resolveProviderConfig, validateProviderConfig } from '../utils/config'
 import { textToBase64 } from '../utils/encoding'
 import {
-  configMerger,
   convertObjectToSnakeCase,
   convertTokenRequestToType,
   oidcErrorHandler,
@@ -34,14 +33,11 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   return eventHandler(async (event: H3Event) => {
     const provider = event.path.split('/')[2] as ProviderKeys
     const runtimeProviderConfig = useRuntimeConfig().oidc.providers[provider] as OidcProviderConfig
-    const config = configMerger(runtimeProviderConfig, providerPresets[provider])
+    const config = resolveProviderConfig(runtimeProviderConfig, providerPresets[provider])
     const hasConfiguredCallbackRedirectUrl =
       typeof runtimeProviderConfig?.callbackRedirectUrl === 'string'
 
-    // Create custom fetch instance for this provider
-    const customFetch = await createProviderFetch(config)
-
-    const validationResult = validateConfig(config, config.requiredProperties)
+    const validationResult = validateProviderConfig(config)
 
     if (!validationResult.valid) {
       logger.error(
@@ -50,6 +46,9 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       )
       return oidcErrorHandler(event, 'Invalid configuration')
     }
+
+    // Create custom fetch instance for this provider
+    const customFetch = await createProviderFetch(config)
 
     const session = await useAuthSession(event, config.sessionConfiguration?.maxAuthSessionAge)
 

--- a/src/runtime/server/handler/login.get.ts
+++ b/src/runtime/server/handler/login.get.ts
@@ -5,13 +5,8 @@ import { useRuntimeConfig } from '#imports'
 import { eventHandler, getQuery, getRequestHeader, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import * as providerPresets from '../../providers'
-import { validateConfig } from '../utils/config'
-import {
-  configMerger,
-  convertObjectToSnakeCase,
-  oidcErrorHandler,
-  useOidcLogger,
-} from '../utils/oidc'
+import { resolveProviderConfig, validateProviderConfig } from '../utils/config'
+import { convertObjectToSnakeCase, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
 import { sanitizeCallbackRedirectUrl } from '../utils/redirect'
 import {
   generatePkceCodeChallenge,
@@ -24,11 +19,11 @@ function loginEventHandler() {
   const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
     const provider = event.path.split('/')[2] as ProviderKeys
-    const config = configMerger(
+    const config = resolveProviderConfig(
       useRuntimeConfig().oidc.providers[provider] as OidcProviderConfig,
       providerPresets[provider],
     )
-    const validationResult = validateConfig(config, config.requiredProperties)
+    const validationResult = validateProviderConfig(config)
 
     if (!validationResult.valid) {
       logger.error(

--- a/src/runtime/server/handler/logout.get.ts
+++ b/src/runtime/server/handler/logout.get.ts
@@ -1,21 +1,36 @@
-import type { OAuthConfig, ProviderKeys, UserSession } from '../../types'
+import type { OAuthConfig, ProviderKeysWithDev, UserSession } from '../../types'
 import type { H3Event } from 'h3'
 import type { OidcProviderConfig } from '../utils/provider'
 import { useRuntimeConfig } from '#imports'
 import { eventHandler, getQuery, getRequestURL, sendRedirect } from 'h3'
 import { withQuery } from 'ufo'
 import * as providerPresets from '../../providers'
-import { configMerger, convertObjectToSnakeCase } from '../utils/oidc'
+import { resolveProviderConfig, validateProviderConfig } from '../utils/config'
+import { convertObjectToSnakeCase, oidcErrorHandler, useOidcLogger } from '../utils/oidc'
 import { clearUserSession, getUserSession } from '../utils/session'
 
 export function logoutEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
+  const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
     // TODO: Is this the best way to get the current provider?
-    const provider = event.path.split('/')[2] as ProviderKeys
-    const config = configMerger(
+    const provider = event.path.split('/')[2] as ProviderKeysWithDev
+    if (provider === 'dev') {
+      await clearUserSession(event)
+      return onSuccess(event, { user: null })
+    }
+    const config = resolveProviderConfig(
       useRuntimeConfig().oidc.providers[provider] as OidcProviderConfig,
       providerPresets[provider as keyof typeof providerPresets],
     )
+    const validationResult = validateProviderConfig(config)
+
+    if (!validationResult.valid) {
+      logger.error(
+        `[${provider}] Missing or empty configuration properties:`,
+        validationResult.missingProperties?.join(', '),
+      )
+      return oidcErrorHandler(event, 'Invalid configuration')
+    }
 
     if (config.logoutUrl) {
       const logoutParams = getQuery(event)

--- a/src/runtime/server/utils/config.ts
+++ b/src/runtime/server/utils/config.ts
@@ -1,7 +1,21 @@
-import type { ProviderConfigs, ProviderKeys } from '../../types'
 import type { OidcProviderConfig } from './provider'
+import { createDefu } from 'defu'
 import { cleanDoubleSlashes, joinURL, parseURL, withHttps, withoutTrailingSlash } from 'ufo'
-import { snakeCase } from './string'
+
+const PLACEHOLDER_RE = /\{(.*?)\}/g
+
+type ProviderConfigSource = Partial<Omit<OidcProviderConfig, 'requiredProperties'>> & {
+  requiredProperties?: string[]
+}
+
+// Custom defu config merger to replace default values instead of merging them, except for requiredProperties
+export const configMerger = createDefu((obj, key, value) => {
+  if (Array.isArray(obj[key]) && Array.isArray(value)) {
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any -- defu merger callback requires flexible assignment
+    obj[key] = (key === 'requiredProperties' ? [...new Set([...obj[key], ...value])] : value) as any
+    return true
+  }
+})
 
 export interface ValidationResult<T> {
   valid: boolean
@@ -45,11 +59,123 @@ export function generateProviderUrl(baseUrl: string, relativeUrl?: string) {
     : withoutTrailingSlash(cleanDoubleSlashes(withHttps(joinURL(baseUrl, '/', relativeUrl || ''))))
 }
 
+function isResolvedString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function replaceProviderPlaceholders(
+  baseUrl: string,
+  config: OidcProviderConfig & Record<string, unknown>,
+): string {
+  let resolvedBaseUrl = baseUrl
+  for (const match of baseUrl.matchAll(PLACEHOLDER_RE)) {
+    const key = match[1]
+    if (!key) continue
+
+    const value = config[key]
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      typeof value === 'bigint'
+    ) {
+      resolvedBaseUrl = resolvedBaseUrl.replace(match[0], String(value))
+    }
+  }
+  return resolvedBaseUrl
+}
+
+function resolveProviderEndpoint(
+  explicitValue: unknown,
+  presetValue: unknown,
+  baseUrl: string | undefined,
+): string | undefined {
+  if (isResolvedString(explicitValue) && explicitValue !== presetValue) return explicitValue
+  if (!isResolvedString(presetValue)) {
+    return isResolvedString(explicitValue) ? explicitValue : undefined
+  }
+  if (!baseUrl || parseURL(presetValue).protocol) return presetValue
+  return generateProviderUrl(baseUrl, presetValue)
+}
+
+export function createProviderRuntimeConfig(
+  configuredProvider: ProviderConfigSource | undefined,
+  providerPreset: ProviderConfigSource,
+): ProviderConfigSource {
+  const runtimeShape = createRuntimeConfigShape(providerPreset) as ProviderConfigSource
+  return configMerger(configuredProvider || {}, runtimeShape) as ProviderConfigSource
+}
+
+function createRuntimeConfigShape(config: object): Record<string, unknown> {
+  const shape: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'function') continue
+    shape[key] =
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? createRuntimeConfigShape(value)
+        : null
+  }
+  return shape
+}
+
+/**
+ * Resolve a runtime provider configuration before validating or using it.
+ * Runtime config already contains Nuxt environment overrides, so it takes
+ * precedence over provider and library defaults.
+ */
+export function resolveProviderConfig(
+  runtimeConfig: ProviderConfigSource | undefined,
+  providerPreset: ProviderConfigSource,
+): OidcProviderConfig {
+  const explicitConfig = runtimeConfig || {}
+  const config = configMerger(explicitConfig, providerPreset) as OidcProviderConfig &
+    Record<string, unknown>
+  const baseUrl = isResolvedString(config.baseUrl)
+    ? replaceProviderPlaceholders(config.baseUrl, config)
+    : undefined
+
+  if (baseUrl) config.baseUrl = baseUrl
+
+  config.authorizationUrl =
+    resolveProviderEndpoint(
+      explicitConfig.authorizationUrl,
+      providerPreset.authorizationUrl,
+      baseUrl,
+    ) || config.authorizationUrl
+  config.tokenUrl =
+    resolveProviderEndpoint(explicitConfig.tokenUrl, providerPreset.tokenUrl, baseUrl) ||
+    config.tokenUrl
+  config.userInfoUrl = resolveProviderEndpoint(
+    explicitConfig.userInfoUrl,
+    providerPreset.userInfoUrl,
+    baseUrl,
+  )
+  config.logoutUrl = resolveProviderEndpoint(
+    explicitConfig.logoutUrl,
+    providerPreset.logoutUrl,
+    baseUrl,
+  )
+
+  replaceInjectedParameters(['clientId'], config, providerPreset)
+  return config
+}
+
+export function getRequiredProviderProperties(config: OidcProviderConfig): string[] {
+  return config.requiredProperties.filter(
+    (property) => property !== 'clientSecret' || config.authenticationScheme !== 'none',
+  )
+}
+
+export function validateProviderConfig(
+  config: OidcProviderConfig,
+): ValidationResult<OidcProviderConfig> {
+  return validateConfig(config, getRequiredProviderProperties(config))
+}
+
 export function replaceInjectedParameters(
   injectedParameters: Array<keyof OidcProviderConfig>,
   providerOptions: OidcProviderConfig,
-  providerPreset: ProviderConfigs[keyof ProviderConfigs],
-  provider: ProviderKeys,
+  providerPreset: ProviderConfigSource,
 ): void {
   const additionalParameterKeys = [
     'additionalAuthParameters',
@@ -64,21 +190,14 @@ export function replaceInjectedParameters(
   additionalParameterKeys.forEach((parameterKey) => {
     const presetParams = providerPreset[parameterKey]
     if (!presetParams) return
-    const providerParams = providerOptions[parameterKey]
-    if (!providerParams) {
-      providerOptions[parameterKey] = {}
-    }
+    providerOptions[parameterKey] = { ...providerOptions[parameterKey] }
     Object.entries(presetParams).forEach(([key, value]) => {
       injectedParameters.forEach((injectedParameter) => {
         const placeholder = `{${injectedParameter}}`
         if ((value as string).includes(placeholder)) {
           providerOptions[parameterKey]![key] = (value as string).replace(
             placeholder,
-            (providerOptions[injectedParameter] as string) ||
-              process.env[
-                `NUXT_OIDC_PROVIDERS_${provider.toUpperCase()}_${snakeCase(injectedParameter).toUpperCase()}`
-              ] ||
-              '',
+            (providerOptions[injectedParameter] as string) || '',
           )
         }
       })

--- a/src/runtime/server/utils/config.ts
+++ b/src/runtime/server/utils/config.ts
@@ -3,6 +3,7 @@ import { createDefu } from 'defu'
 import { cleanDoubleSlashes, joinURL, parseURL, withHttps, withoutTrailingSlash } from 'ufo'
 
 const PLACEHOLDER_RE = /\{(.*?)\}/g
+const RUNTIME_CONFIG_UNSET = '__NUXT_OIDC_RUNTIME_CONFIG_UNSET__'
 
 type ProviderConfigSource = Partial<Omit<OidcProviderConfig, 'requiredProperties'>> & {
   requiredProperties?: string[]
@@ -89,7 +90,9 @@ function resolveProviderEndpoint(
   explicitValue: unknown,
   presetValue: unknown,
   baseUrl: string | undefined,
+  allowEmpty: boolean = false,
 ): string | undefined {
+  if (allowEmpty && explicitValue === '') return ''
   if (isResolvedString(explicitValue) && explicitValue !== presetValue) return explicitValue
   if (!isResolvedString(presetValue)) {
     return isResolvedString(explicitValue) ? explicitValue : undefined
@@ -113,9 +116,29 @@ function createRuntimeConfigShape(config: object): Record<string, unknown> {
     shape[key] =
       value && typeof value === 'object' && !Array.isArray(value)
         ? createRuntimeConfigShape(value)
-        : null
+        : RUNTIME_CONFIG_UNSET
   }
   return shape
+}
+
+function removeRuntimeConfigSentinels(value: unknown): unknown {
+  if (value === RUNTIME_CONFIG_UNSET) return undefined
+  if (Array.isArray(value)) return value.map(removeRuntimeConfigSentinels)
+  if (!value || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, nestedValue]) => {
+      const resolvedValue = removeRuntimeConfigSentinels(nestedValue)
+      return resolvedValue === undefined ? [] : [[key, resolvedValue]]
+    }),
+  )
+}
+
+export function hasExplicitProviderConfig(
+  runtimeConfig: ProviderConfigSource | undefined,
+  property: keyof OidcProviderConfig,
+): boolean {
+  return runtimeConfig?.[property] !== undefined && runtimeConfig[property] !== RUNTIME_CONFIG_UNSET
 }
 
 /**
@@ -127,7 +150,7 @@ export function resolveProviderConfig(
   runtimeConfig: ProviderConfigSource | undefined,
   providerPreset: ProviderConfigSource,
 ): OidcProviderConfig {
-  const explicitConfig = runtimeConfig || {}
+  const explicitConfig = removeRuntimeConfigSentinels(runtimeConfig || {}) as ProviderConfigSource
   const config = configMerger(explicitConfig, providerPreset) as OidcProviderConfig &
     Record<string, unknown>
   const baseUrl = isResolvedString(config.baseUrl)
@@ -149,11 +172,13 @@ export function resolveProviderConfig(
     explicitConfig.userInfoUrl,
     providerPreset.userInfoUrl,
     baseUrl,
+    true,
   )
   config.logoutUrl = resolveProviderEndpoint(
     explicitConfig.logoutUrl,
     providerPreset.logoutUrl,
     baseUrl,
+    true,
   )
 
   replaceInjectedParameters(['clientId'], config, providerPreset)

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -2,7 +2,6 @@ import type { RefreshTokenRequest, TokenRequest, TokenRespose, UserSession } fro
 import type { H3Event } from 'h3'
 import type { OidcProviderConfig } from './provider'
 import { createConsola } from 'consola'
-import { createDefu } from 'defu'
 import { sendRedirect } from 'h3'
 import { normalizeURL } from 'ufo'
 import { createProviderFetch } from './provider'
@@ -14,15 +13,6 @@ import { snakeCase } from './string'
 export function useOidcLogger() {
   return createConsola().withDefaults({ tag: 'nuxt-oidc-auth', message: '[nuxt-oidc-auth]:' })
 }
-
-// Custom defu config merger to replace default values instead of merging them, except for requiredProperties
-export const configMerger = createDefu((obj, key, value) => {
-  if (Array.isArray(obj[key]) && Array.isArray(value)) {
-    // oxlint-disable-next-line typescript-eslint/no-explicit-any -- defu merger callback requires flexible assignment
-    obj[key] = (key === 'requiredProperties' ? [...new Set([...obj[key], ...value])] : value) as any
-    return true
-  }
-})
 
 export async function refreshAccessToken(refreshToken: string, config: OidcProviderConfig) {
   const logger = useOidcLogger()

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -14,7 +14,8 @@ import { createError, deleteCookie, sendRedirect, useSession } from 'h3'
 import { createHooks } from 'hookable'
 import { useStorage } from 'nitropack/runtime'
 import * as providerPresets from '../../providers'
-import { configMerger, refreshAccessToken, useOidcLogger } from './oidc'
+import { resolveProviderConfig, validateProviderConfig } from './config'
+import { refreshAccessToken, useOidcLogger } from './oidc'
 import { decryptToken, encryptToken } from './security'
 import { resolveMissingPersistentSessionMode } from './session-options'
 
@@ -134,10 +135,19 @@ export async function refreshUserSession(event: H3Event, options: SessionBehavio
   const tokenKey = process.env.NUXT_OIDC_TOKEN_KEY as string
   const refreshToken = await decryptToken(persistentSession.refreshToken, tokenKey)
 
-  const config = configMerger(
+  const config = resolveProviderConfig(
     useRuntimeConfig().oidc.providers[provider] as OidcProviderConfig,
     providerPresets[provider],
   )
+  const validationResult = validateProviderConfig(config)
+  if (!validationResult.valid) {
+    logger.error(
+      `[${provider}] Missing or empty configuration properties:`,
+      validationResult.missingProperties?.join(', '),
+    )
+    await clearUserSession(event)
+    return await handleSessionError(event, `[${provider}] Invalid configuration`, options)
+  }
 
   let tokenRefreshResponse: Awaited<ReturnType<typeof refreshAccessToken>>
   try {

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -194,12 +194,8 @@ export async function refreshUserSession(event: H3Event, options: SessionBehavio
 
   return {
     ...session.data,
-    ...(tokens.accessToken &&
-      (useRuntimeConfig(event).oidc.providers[provider]?.exposeAccessToken ||
-        providerPresets[provider]?.exposeAccessToken) && { accessToken: tokens.accessToken }),
-    ...(tokens.idToken &&
-      (useRuntimeConfig(event).oidc.providers[provider]?.exposeIdToken ||
-        providerPresets[provider]?.exposeIdToken) && { idToken: tokens.idToken }),
+    ...(tokens.accessToken && config.exposeAccessToken && { accessToken: tokens.accessToken }),
+    ...(tokens.idToken && config.exposeIdToken && { idToken: tokens.idToken }),
   }
 }
 
@@ -281,10 +277,11 @@ export async function getUserSession(event: H3Event, options: SessionBehaviorOpt
   }
 
   // Expose tokens if configured
-  const providerConfig = useRuntimeConfig(event).oidc.providers[provider]
-  const exposeAccessToken =
-    providerConfig?.exposeAccessToken || providerPresets[provider]?.exposeAccessToken
-  const exposeIdToken = providerConfig?.exposeIdToken || providerPresets[provider]?.exposeIdToken
+  const providerConfig = resolveProviderConfig(
+    useRuntimeConfig(event).oidc.providers[provider] as OidcProviderConfig,
+    providerPresets[provider],
+  )
+  const { exposeAccessToken, exposeIdToken } = providerConfig
 
   if (exposeAccessToken || exposeIdToken) {
     const persistentSession = (await useStorage('oidc').getItem<PersistentSession>(
@@ -333,16 +330,16 @@ function _useSession(event: H3Event) {
     )
     // Merge providerSessionConfigs
     for (const key of Object.keys(runtimeConfig.providers) as ProviderKeys[]) {
-      providerSessionConfigs[key] = defu(
-        runtimeConfig.providers[key]?.sessionConfiguration,
-        providerPresets[key].sessionConfiguration,
-        {
-          automaticRefresh: config.automaticRefresh,
-          expirationCheck: config.expirationCheck,
-          expirationThreshold: config.expirationThreshold,
-          missingPersistentSession,
-        },
-      ) as ProviderSessionConfig
+      const providerConfig = resolveProviderConfig(
+        runtimeConfig.providers[key] as OidcProviderConfig,
+        providerPresets[key],
+      )
+      providerSessionConfigs[key] = defu(providerConfig.sessionConfiguration, {
+        automaticRefresh: config.automaticRefresh,
+        expirationCheck: config.expirationCheck,
+        expirationThreshold: config.expirationThreshold,
+        missingPersistentSession,
+      }) as ProviderSessionConfig
     }
   }
   return useSession<UserSession>(event, sessionConfig)

--- a/test/functional/handler-harness.test.ts
+++ b/test/functional/handler-harness.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+const runtimeConfig = {
+  oidc: {
+    session: {
+      maxAge: 3600,
+      automaticRefresh: false,
+      expirationCheck: false,
+    },
+    providers: {
+      oidc: {
+        clientId: 'functional-client',
+        clientSecret: 'functional-secret',
+        authorizationUrl: 'https://identity.example.test/authorize',
+        tokenUrl: 'https://identity.example.test/token',
+        redirectUri: 'https://app.example.test/auth/oidc/callback',
+        requiredProperties: [
+          'clientId',
+          'clientSecret',
+          'authorizationUrl',
+          'tokenUrl',
+          'redirectUri',
+        ],
+      },
+    },
+  },
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('functional handler harness', () => {
+  it('invokes login with inspectable auth state and a cookie jar shared across requests', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig,
+      cookies: { consent: 'accepted' },
+    })
+    const loginHandler = (await import('../../src/runtime/server/handler/login.get')).default
+
+    const firstRequest = harness.createEvent({
+      path: '/auth/oidc/login',
+      query: { callbackRedirectUrl: '/account' },
+      headers: { referer: 'https://app.example.test/start' },
+    })
+    await loginHandler(firstRequest.event)
+    firstRequest.commitResponseCookies()
+
+    expect(firstRequest.response.status).toBe(302)
+    expect(firstRequest.response.headers['set-cookie']).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^oidc=functional-session-\d+; Path=\/$/)]),
+    )
+    const authorizationUrl = new URL(firstRequest.response.location!)
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+      'https://identity.example.test/authorize',
+    )
+    expect(authorizationUrl.searchParams.get('client_id')).toBe('functional-client')
+
+    const firstAuthSession = harness.inspectSession('oidc')
+    expect(firstAuthSession?.clearCount).toBe(1)
+    expect(firstAuthSession?.operations).toContain('update')
+    expect(firstAuthSession?.data).toMatchObject({
+      callbackRedirectUrl: '/account',
+      referer: 'https://app.example.test/start',
+    })
+    expect(firstAuthSession?.data.state).toEqual(expect.any(String))
+    expect(firstAuthSession?.data.codeVerifier).toEqual(expect.any(String))
+
+    const secondRequest = harness.createEvent({ path: '/auth/oidc/login' })
+    await loginHandler(secondRequest.event)
+
+    expect(secondRequest.response.status).toBe(302)
+    expect(harness.cookieJar.get('consent')).toBe('accepted')
+    expect(harness.inspectSession('oidc')?.id).toBe(firstAuthSession?.id)
+    expect(harness.inspectSession('oidc')?.clearCount).toBe(2)
+  })
+
+  it('invokes callback POST with configurable body and cookies', async () => {
+    const harness = new HandlerHarness({ runtimeConfig })
+    const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+    const request = harness.createEvent({
+      method: 'POST',
+      path: '/auth/oidc/callback',
+      body: { admin_consent: 'accepted' },
+      cookies: { transaction: 'callback' },
+    })
+
+    await callbackHandler(request.event)
+
+    expect(request.response).toMatchObject({
+      status: 200,
+      location: 'https://app.example.test/auth/oidc/login',
+    })
+    const { getCookie } = await import('h3')
+    expect(getCookie(request.event, 'transaction')).toBe('callback')
+    expect(harness.cookieJar.get('transaction')).toBeUndefined()
+    expect(harness.inspectSession('oidc')).toMatchObject({
+      clearCount: 0,
+      data: {},
+      operations: [],
+    })
+  })
+
+  it('invokes logout and exposes cleared user-session state', async () => {
+    const harness = new HandlerHarness({ runtimeConfig })
+    harness.cookieJar.seedSession('nuxt-oidc-auth', {
+      provider: 'oidc',
+      canRefresh: false,
+      expireAt: Math.trunc(Date.now() / 1000) + 300,
+    })
+    const logoutHandler = (await import('../../src/runtime/server/handler/logout.get')).default
+    const request = harness.createEvent({ path: '/auth/oidc/logout' })
+
+    await logoutHandler(request.event)
+
+    expect(request.response).toMatchObject({
+      status: 302,
+      location: 'https://app.example.test',
+    })
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({
+      clearCount: 1,
+      data: {},
+      operations: ['clear'],
+    })
+    expect(request.response.headers['set-cookie']).toEqual(
+      expect.arrayContaining(['nuxt-oidc-auth=; Max-Age=0; Path=/']),
+    )
+    request.commitResponseCookies()
+    expect(harness.cookieJar.get('nuxt-oidc-auth')).toBeUndefined()
+  })
+
+  it('clears dev-mode sessions and redirects locally without provider resolution', async () => {
+    const harness = new HandlerHarness({ runtimeConfig })
+    harness.cookieJar.seedSession('nuxt-oidc-auth', {
+      provider: 'dev',
+      canRefresh: false,
+      expireAt: Math.trunc(Date.now() / 1000) + 300,
+    })
+    const logoutHandler = (await import('../../src/runtime/server/handler/logout.get')).default
+    const request = harness.createEvent({ path: '/auth/dev/logout' })
+
+    await logoutHandler(request.event)
+
+    expect(request.response).toMatchObject({
+      status: 302,
+      location: 'https://app.example.test',
+    })
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({
+      clearCount: 1,
+      data: {},
+    })
+  })
+
+  it('isolates pre-created request cookies until response cookies are committed', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig,
+      cookies: { obsolete: 'remove-me', preference: 'original' },
+    })
+    const firstRequest = harness.createEvent({ path: '/first' })
+    const concurrentRequest = harness.createEvent({ path: '/concurrent' })
+    const { deleteCookie, getCookie, setCookie, useSession } = await import('h3')
+
+    setCookie(firstRequest.event, 'preference', 'updated')
+    deleteCookie(firstRequest.event, 'obsolete')
+    const firstSession = await useSession(firstRequest.event, {
+      name: 'oidc',
+      password: 'functional-test-password',
+    })
+    await firstSession.update({ state: 'first' })
+
+    expect(firstRequest.response.headers['set-cookie']).toEqual([
+      'preference=updated; Path=/',
+      'obsolete=; Max-Age=0; Path=/',
+      `oidc=${firstSession.id}; Path=/`,
+    ])
+
+    firstRequest.commitResponseCookies()
+
+    expect(getCookie(concurrentRequest.event, 'preference')).toBe('original')
+    expect(getCookie(concurrentRequest.event, 'obsolete')).toBe('remove-me')
+    const concurrentSession = await useSession(concurrentRequest.event, {
+      name: 'oidc',
+      password: 'functional-test-password',
+    })
+    expect(concurrentSession.id).not.toBe(firstSession.id)
+
+    const laterRequest = harness.createEvent({ path: '/later' })
+    expect(getCookie(laterRequest.event, 'preference')).toBe('updated')
+    expect(getCookie(laterRequest.event, 'obsolete')).toBeUndefined()
+    expect(
+      (
+        await useSession(laterRequest.event, {
+          name: 'oidc',
+          password: 'functional-test-password',
+        })
+      ).id,
+    ).toBe(firstSession.id)
+  })
+
+  it('generates RS256 key material and intercepts remote JWKS validation', async () => {
+    const fixture = await createRs256Fixture()
+    const issuer = 'https://identity.example.test'
+    const jwksUri = `${issuer}/jwks`
+    const token = await fixture.sign({ aud: 'functional-client', iss: issuer, sub: 'user-1' })
+    const expiredToken = await fixture.sign({
+      aud: 'functional-client',
+      exp: Math.trunc(Date.now() / 1000) - 60,
+      iss: issuer,
+      sub: 'expired-user',
+    })
+    const interceptor = interceptFetch([
+      {
+        url: jwksUri,
+        respond: () => Response.json(fixture.jwks),
+      },
+    ])
+
+    const { validateToken } = await import('../../src/runtime/server/utils/security')
+    const payload = await validateToken(token, {
+      audience: 'functional-client',
+      issuer,
+      jwksUri,
+    })
+
+    expect(payload.sub).toBe('user-1')
+    await expect(
+      validateToken(expiredToken, {
+        audience: 'functional-client',
+        issuer,
+        jwksUri,
+      }),
+    ).rejects.toThrow()
+    expect(fixture.publicJwk).toMatchObject({ alg: 'RS256', kid: 'functional-test-key' })
+    expect(fixture.privateJwk.d).toEqual(expect.any(String))
+    expect(interceptor.requests).toHaveLength(2)
+    interceptor.restore()
+  })
+})

--- a/test/functional/handler-harness.test.ts
+++ b/test/functional/handler-harness.test.ts
@@ -152,6 +152,38 @@ describe('functional handler harness', () => {
     })
   })
 
+  it('clears local sessions when provider configuration is invalid', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig: {
+        ...runtimeConfig,
+        oidc: {
+          ...runtimeConfig.oidc,
+          providers: {
+            oidc: {
+              ...runtimeConfig.oidc.providers.oidc,
+              clientId: '',
+            },
+          },
+        },
+      },
+    })
+    harness.cookieJar.seedSession('nuxt-oidc-auth', {
+      provider: 'oidc',
+      canRefresh: false,
+      expireAt: Math.trunc(Date.now() / 1000) + 300,
+    })
+    const logoutHandler = (await import('../../src/runtime/server/handler/logout.get')).default
+    const request = harness.createEvent({ path: '/auth/oidc/logout' })
+
+    await logoutHandler(request.event)
+
+    expect(request.response).toMatchObject({ status: 302, location: '/' })
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({
+      clearCount: 1,
+      data: {},
+    })
+  })
+
   it('isolates pre-created request cookies until response cookies are committed', async () => {
     const harness = new HandlerHarness({
       runtimeConfig,

--- a/test/functional/handler-harness.ts
+++ b/test/functional/handler-harness.ts
@@ -1,0 +1,411 @@
+import type { AuthSession, UserSession } from '../../src/runtime/types'
+import type { H3Event, SessionConfig } from 'h3'
+import { exportJWK, generateKeyPair, SignJWT } from 'jose'
+import { vi } from 'vitest'
+
+type SessionData = AuthSession | UserSession | Record<string, unknown>
+
+interface HarnessSession<T extends SessionData> {
+  id: string
+  readonly data: T
+  clear: () => Promise<void>
+  update: (data: Partial<T>) => Promise<{ data: T; id: string }>
+}
+
+interface StoredSession {
+  id: string
+  name: string
+  data: Record<string, unknown>
+  clearCount: number
+  updates: Record<string, unknown>[]
+  operations: Array<'clear' | 'update'>
+}
+
+export interface SessionInspection {
+  id: string
+  name: string
+  data: Record<string, unknown>
+  clearCount: number
+  updates: Record<string, unknown>[]
+  operations: Array<'clear' | 'update'>
+}
+
+export interface HandlerResponse {
+  status: number
+  headers: Record<string, string | string[]>
+  location?: string
+}
+
+export interface FakeEventOptions {
+  method?: string
+  path: string
+  query?: Record<string, string | string[] | undefined>
+  body?: unknown
+  cookies?: Record<string, string>
+  headers?: Record<string, string>
+  origin?: string
+}
+
+interface EventHarnessContext {
+  body: unknown
+  jar: CookieJar
+  pendingCookies: Map<string, string | undefined>
+  query: Record<string, string | string[] | undefined>
+  requestCookies: ReadonlyMap<string, string>
+  requestUrl: URL
+  response: HandlerResponse
+  sessions: Map<string, HarnessSession<SessionData>>
+}
+
+interface HarnessState {
+  current?: HandlerHarness
+}
+
+const mockState = vi.hoisted<HarnessState>(() => ({}))
+
+function activeHarness(): HandlerHarness {
+  if (!mockState.current) throw new Error('Create a handler harness before invoking a handler')
+  return mockState.current
+}
+
+function eventContext(event: H3Event): EventHarnessContext {
+  const context = event.context.handlerHarness as EventHarnessContext | undefined
+  if (!context) throw new Error('Event was not created by HandlerHarness')
+  return context
+}
+
+function appendSetCookie(event: H3Event, value: string): void {
+  const response = eventContext(event).response
+  const existing = response.headers['set-cookie']
+  response.headers['set-cookie'] = existing
+    ? [...(Array.isArray(existing) ? existing : [existing]), value]
+    : [value]
+}
+
+function queueCookie(event: H3Event, name: string, value: string | undefined): void {
+  const context = eventContext(event)
+  context.pendingCookies.set(name, value)
+  appendSetCookie(
+    event,
+    value === undefined
+      ? `${name}=; Max-Age=0; Path=/`
+      : `${name}=${encodeURIComponent(value)}; Path=/`,
+  )
+}
+
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => activeHarness().runtimeConfig,
+}))
+
+vi.mock('nitropack/runtime', () => ({
+  useStorage: (namespace: string) => activeHarness().storage(namespace),
+}))
+
+vi.mock('h3', async (importOriginal) => {
+  // oxlint-disable-next-line typescript/consistent-type-imports -- Vitest importOriginal requires an inline module type
+  const actual = await importOriginal<typeof import('h3')>()
+  return {
+    ...actual,
+    deleteCookie: (event: H3Event, name: string) => {
+      queueCookie(event, name, undefined)
+    },
+    getCookie: (event: H3Event, name: string) => eventContext(event).requestCookies.get(name),
+    getQuery: (event: H3Event) => eventContext(event).query,
+    getRequestHeader: (event: H3Event, name: string) => {
+      const value = event.node.req.headers[name.toLowerCase()]
+      return Array.isArray(value) ? value[0] : value
+    },
+    getRequestURL: (event: H3Event) => eventContext(event).requestUrl,
+    readBody: (event: H3Event) => Promise.resolve(eventContext(event).body),
+    sendRedirect: (event: H3Event, location: string, status: number = 302) => {
+      const response = eventContext(event).response
+      response.status = status
+      response.location = location
+      response.headers.location = location
+      event.node.res.statusCode = status
+      event.node.res.setHeader('location', location)
+      return location
+    },
+    setResponseStatus: (event: H3Event, status: number) => {
+      eventContext(event).response.status = status
+      event.node.res.statusCode = status
+    },
+    setCookie: (event: H3Event, name: string, value: string) => {
+      queueCookie(event, name, value)
+    },
+    useSession: <T extends SessionData>(event: H3Event, config: SessionConfig) =>
+      Promise.resolve(eventContext(event).jar.useSession<T>(event, config.name || 'h3')),
+  }
+})
+
+function cloneData<T>(value: T): T {
+  return structuredClone(value)
+}
+
+export class CookieJar {
+  readonly #cookies = new Map<string, string>()
+  readonly #sessions = new Map<string, StoredSession[]>()
+  #nextSessionId = 0
+
+  constructor(cookies: Record<string, string> = {}) {
+    for (const [name, value] of Object.entries(cookies)) this.set(name, value)
+  }
+
+  delete(name: string): void {
+    this.#cookies.delete(name)
+  }
+
+  get(name: string): string | undefined {
+    return this.#cookies.get(name)
+  }
+
+  set(name: string, value: string): void {
+    this.#cookies.set(name, value)
+  }
+
+  entries(): Record<string, string> {
+    return Object.fromEntries(this.#cookies)
+  }
+
+  seedSession<T extends SessionData>(name: string, data: T, id?: string): SessionInspection {
+    const session = this.#createSession(name, id)
+    session.data = cloneData(data as Record<string, unknown>)
+    this.#cookies.set(name, session.id)
+    return this.#inspect(session)
+  }
+
+  inspectSession(name: string): SessionInspection | undefined {
+    const sessions = this.#sessions.get(name)
+    const session = sessions?.at(-1)
+    return session ? this.#inspect(session) : undefined
+  }
+
+  useSession<T extends SessionData>(event: H3Event, name: string): HarnessSession<T> {
+    const context = eventContext(event)
+    const eventSession = context.sessions.get(name)
+    if (eventSession) return eventSession as HarnessSession<T>
+
+    const cookieSessionId = context.requestCookies.get(name)
+    const existing = this.#sessions.get(name)?.find((session) => session.id === cookieSessionId)
+    const stored = existing || this.#createSession(name, cookieSessionId)
+
+    const session = {
+      id: stored.id,
+      get data() {
+        return stored.data as T
+      },
+      clear: async () => {
+        stored.operations.push('clear')
+        stored.clearCount += 1
+        stored.data = {}
+        queueCookie(event, name, undefined)
+      },
+      update: async (data: Partial<T>) => {
+        const update = cloneData(data as Record<string, unknown>)
+        stored.operations.push('update')
+        stored.updates.push(update)
+        Object.assign(stored.data, update)
+        queueCookie(event, name, stored.id)
+        return { id: stored.id, data: stored.data as T }
+      },
+    }
+    context.sessions.set(name, session as HarnessSession<SessionData>)
+    return session
+  }
+
+  #createSession(name: string, requestedId?: string): StoredSession {
+    const session: StoredSession = {
+      id: requestedId || `functional-session-${++this.#nextSessionId}`,
+      name,
+      data: {},
+      clearCount: 0,
+      updates: [],
+      operations: [],
+    }
+    const sessions = this.#sessions.get(name) || []
+    sessions.push(session)
+    this.#sessions.set(name, sessions)
+    return session
+  }
+
+  #inspect(session: StoredSession): SessionInspection {
+    return cloneData(session)
+  }
+}
+
+export interface HandlerHarnessOptions {
+  runtimeConfig: Record<string, unknown>
+  cookies?: Record<string, string>
+}
+
+export class HandlerHarness {
+  readonly cookieJar: CookieJar
+  readonly runtimeConfig: Record<string, unknown>
+  readonly #storage = new Map<string, Map<string, unknown>>()
+
+  constructor(options: HandlerHarnessOptions) {
+    this.runtimeConfig = options.runtimeConfig
+    this.cookieJar = new CookieJar(options.cookies)
+    mockState.current = this
+  }
+
+  createEvent(options: FakeEventOptions): {
+    commitResponseCookies: () => void
+    event: H3Event
+    response: HandlerResponse
+  } {
+    const method = options.method?.toUpperCase() || 'GET'
+    const origin = options.origin || 'https://app.example.test'
+    const requestUrl = new URL(options.path, origin)
+    for (const [name, value] of Object.entries(options.query || {})) {
+      for (const item of Array.isArray(value) ? value : [value]) {
+        if (item !== undefined) requestUrl.searchParams.append(name, item)
+      }
+    }
+
+    const requestCookies = new Map(Object.entries(this.cookieJar.entries()))
+    for (const [name, value] of Object.entries(options.cookies || {})) {
+      requestCookies.set(name, value)
+    }
+    const pendingCookies = new Map<string, string | undefined>()
+    const response: HandlerResponse = { status: 200, headers: {} }
+    const requestHeaders: Record<string, string> = {}
+    for (const [name, value] of Object.entries(options.headers || {})) {
+      requestHeaders[name.toLowerCase()] = value
+    }
+    const cookieHeader = [...requestCookies.entries()]
+      .map(([name, value]) => `${name}=${value}`)
+      .join('; ')
+    if (cookieHeader) requestHeaders.cookie = cookieHeader
+
+    const event = {
+      context: {
+        handlerHarness: {
+          body: options.body,
+          jar: this.cookieJar,
+          pendingCookies,
+          query: options.query || {},
+          requestCookies,
+          requestUrl,
+          response,
+          sessions: new Map(),
+        } satisfies EventHarnessContext,
+      },
+      method,
+      path: requestUrl.pathname,
+      node: {
+        req: {
+          headers: requestHeaders,
+          method,
+          url: `${requestUrl.pathname}${requestUrl.search}`,
+        },
+        res: {
+          get statusCode() {
+            return response.status
+          },
+          set statusCode(status: number) {
+            response.status = status
+          },
+          getHeader: (name: string) => response.headers[name.toLowerCase()],
+          removeHeader: (name: string) => delete response.headers[name.toLowerCase()],
+          setHeader: (name: string, value: number | string | string[]) => {
+            const normalizedName = name.toLowerCase()
+            response.headers[normalizedName] = Array.isArray(value)
+              ? value.map(String)
+              : String(value)
+            if (normalizedName === 'location') response.location = String(value)
+          },
+        },
+      },
+    } as unknown as H3Event
+
+    return {
+      commitResponseCookies: () => {
+        for (const [name, value] of pendingCookies) {
+          if (value === undefined) this.cookieJar.delete(name)
+          else this.cookieJar.set(name, value)
+        }
+        pendingCookies.clear()
+      },
+      event,
+      response,
+    }
+  }
+
+  inspectSession(name: string): SessionInspection | undefined {
+    return this.cookieJar.inspectSession(name)
+  }
+
+  inspectStorage(namespace: string): ReadonlyMap<string, unknown> {
+    return this.#storageFor(namespace)
+  }
+
+  storage(namespace: string) {
+    const data = this.#storageFor(namespace)
+    return {
+      getItem: async <T>(key: string) => (data.get(key) as T | undefined) ?? null,
+      removeItem: async (key: string) => {
+        data.delete(key)
+      },
+      setItem: async <T>(key: string, value: T) => {
+        data.set(key, value)
+      },
+    }
+  }
+
+  #storageFor(namespace: string): Map<string, unknown> {
+    const existing = this.#storage.get(namespace)
+    if (existing) return existing
+    const data = new Map<string, unknown>()
+    this.#storage.set(namespace, data)
+    return data
+  }
+}
+
+export interface FetchRoute {
+  method?: string
+  url: string | RegExp
+  respond: (request: Request) => Response | Promise<Response>
+}
+
+export function interceptFetch(routes: FetchRoute[]) {
+  const requests: Request[] = []
+  const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const request = new Request(input, init)
+    requests.push(request)
+    const route = routes.find(({ method, url }) => {
+      const methodMatches = !method || request.method === method.toUpperCase()
+      const urlMatches = typeof url === 'string' ? request.url === url : url.test(request.url)
+      return methodMatches && urlMatches
+    })
+    if (!route) throw new Error(`Unexpected fetch: ${request.method} ${request.url}`)
+    return await route.respond(request)
+  })
+
+  return {
+    fetchMock,
+    requests,
+    restore: () => fetchMock.mockRestore(),
+  }
+}
+
+export async function createRs256Fixture(kid: string = 'functional-test-key') {
+  const { privateKey, publicKey } = await generateKeyPair('RS256', { extractable: true })
+  const publicJwk = { ...(await exportJWK(publicKey)), alg: 'RS256', kid, use: 'sig' }
+  const privateJwk = { ...(await exportJWK(privateKey)), alg: 'RS256', kid, use: 'sig' }
+
+  return {
+    jwks: { keys: [publicJwk] },
+    privateJwk,
+    publicJwk,
+    sign: async (
+      payload: Record<string, unknown>,
+      options: { expiresIn?: number | string | Date } = {},
+    ) => {
+      let token = new SignJWT(payload).setProtectedHeader({ alg: 'RS256', kid })
+      if (payload.iat === undefined) token = token.setIssuedAt()
+      if (payload.exp === undefined) token = token.setExpirationTime(options.expiresIn ?? '5m')
+      return await token.sign(privateKey)
+    },
+  }
+}

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1,0 +1,39 @@
+import { fileURLToPath } from 'node:url'
+import { loadNuxt } from '@nuxt/kit'
+import { describe, expect, it } from 'vitest'
+
+describe('module setup', () => {
+  it('registers SSO runtime support when static provider config disables it', async () => {
+    const nuxt = await loadNuxt({
+      cwd: fileURLToPath(new URL('../fixtures/oidcApp', import.meta.url)),
+      dev: false,
+      overrides: {
+        oidc: {
+          providers: {
+            oidc: {
+              redirectUri: 'http://localhost:3000/auth/oidc/callback',
+              sessionConfiguration: { singleSignOut: false },
+            },
+            keycloak: {
+              redirectUri: 'http://localhost:3000/auth/keycloak/callback',
+              sessionConfiguration: { singleSignOut: false },
+            },
+          },
+        },
+      },
+    })
+
+    try {
+      expect(
+        nuxt.options.plugins.some((plugin) =>
+          String(typeof plugin === 'string' ? plugin : plugin.src).includes('sso.client'),
+        ),
+      ).toBe(true)
+      expect(nuxt.options.serverHandlers).toContainEqual(
+        expect.objectContaining({ route: '/api/_auth/sso', method: 'get' }),
+      )
+    } finally {
+      await nuxt.close()
+    }
+  })
+})

--- a/test/unit/session/sliding-expiry.test.ts
+++ b/test/unit/session/sliding-expiry.test.ts
@@ -23,13 +23,18 @@ const mockProviderConfig = {
   exposeAccessToken: false,
   exposeIdToken: false,
 }
+const runtimeProviderConfig = {
+  ...mockProviderConfig,
+  exposeAccessToken: '__NUXT_OIDC_RUNTIME_CONFIG_UNSET__',
+  exposeIdToken: '__NUXT_OIDC_RUNTIME_CONFIG_UNSET__',
+}
 
 vi.mock('#imports', () => ({
   useRuntimeConfig: () => ({
     oidc: {
       session: { maxAge: 1800 },
       providers: {
-        oidc: mockProviderConfig,
+        oidc: runtimeProviderConfig,
       },
     },
   }),
@@ -154,12 +159,14 @@ describe('sliding session expiry', () => {
     const { refreshUserSession } = await import('../../../src/runtime/server/utils/session')
 
     const beforeRefresh = Date.now()
-    await refreshUserSession(event)
+    const refreshedSession = await refreshUserSession(event)
     const afterRefresh = Date.now()
 
     const rawSession = event.context.sessions![SESSION_NAME]!
     expect(rawSession.createdAt).toBeGreaterThanOrEqual(beforeRefresh)
     expect(rawSession.createdAt).toBeLessThanOrEqual(afterRefresh)
     expect(rawSession.createdAt).not.toBe(originalCreatedAt)
+    expect(refreshedSession).not.toHaveProperty('accessToken')
+    expect(refreshedSession).not.toHaveProperty('idToken')
   })
 })

--- a/test/unit/session/sliding-expiry.test.ts
+++ b/test/unit/session/sliding-expiry.test.ts
@@ -41,7 +41,6 @@ vi.mock('../../../src/runtime/server/utils/oidc', () => ({
     warn: vi.fn(),
     error: vi.fn(),
   }),
-  configMerger: (_runtime: unknown, _preset: unknown) => mockProviderConfig,
   refreshAccessToken: vi.fn().mockResolvedValue({
     user: { provider: 'oidc', userName: 'test-user' },
     tokens: {
@@ -54,6 +53,11 @@ vi.mock('../../../src/runtime/server/utils/oidc', () => ({
       iat: Math.trunc(Date.now() / 1000),
     },
   }),
+}))
+
+vi.mock('../../../src/runtime/server/utils/config', () => ({
+  resolveProviderConfig: () => mockProviderConfig,
+  validateProviderConfig: () => ({ valid: true, missingProperties: [] }),
 }))
 
 vi.mock('../../../src/runtime/server/utils/security', () => ({

--- a/test/unit/utils/config.test.ts
+++ b/test/unit/utils/config.test.ts
@@ -8,7 +8,15 @@
 
 import { defu } from 'defu'
 import { describe, expect, it } from 'vitest'
-import { replaceInjectedParameters, validateConfig } from '../../../src/runtime/server/utils/config'
+import { keycloak, oidc, zitadel } from '../../../src/runtime/providers'
+import {
+  createProviderRuntimeConfig,
+  replaceInjectedParameters,
+  resolveProviderConfig,
+  validateConfig,
+  validateProviderConfig,
+} from '../../../src/runtime/server/utils/config'
+import { resolveCallbackRedirectUrl } from '../../../src/runtime/server/utils/redirect'
 import { snakeCase } from '../../../src/runtime/server/utils/string'
 
 function parseBoolean(value: string | undefined): boolean {
@@ -114,8 +122,8 @@ describe('configuration Utilities', () => {
 
     it('should detect empty and whitespace-only required values', () => {
       const incompleteConfig = {
-        clientId: 'test-client',
-        clientSecret: '   ',
+        clientId: '   ',
+        clientSecret: null,
         baseUrl: '',
       }
 
@@ -123,7 +131,9 @@ describe('configuration Utilities', () => {
       const result = validateConfig(incompleteConfig, requiredFields)
 
       expect(result.valid).toBe(false)
-      expect(result.missingProperties).toEqual(expect.arrayContaining(['clientSecret', 'baseUrl']))
+      expect(result.missingProperties).toEqual(
+        expect.arrayContaining(['clientId', 'clientSecret', 'baseUrl']),
+      )
     })
 
     it('should allow required boolean and numeric values', () => {
@@ -162,6 +172,161 @@ describe('configuration Utilities', () => {
 
       expect(emptyScopes.length > 0).toBe(false)
       expect(invalidScopes.every((s) => s.length > 0)).toBe(false)
+    })
+  })
+
+  describe('resolved provider configuration', () => {
+    it('replaces empty configured placeholders with Nuxt runtime overrides before derivation', () => {
+      const configuredProvider = {
+        baseUrl: '',
+        clientId: '',
+        clientSecret: '',
+        redirectUri: '',
+      }
+      const runtimeProvider = {
+        ...createProviderRuntimeConfig(configuredProvider, keycloak),
+        baseUrl: 'https://runtime.example.com/realms/example',
+        clientId: 'runtime-client',
+        clientSecret: 'runtime-secret',
+        redirectUri: 'https://app.example.com/auth/keycloak/callback',
+      }
+      const config = resolveProviderConfig(runtimeProvider, keycloak)
+
+      expect(config.authorizationUrl).toBe(
+        'https://runtime.example.com/realms/example/protocol/openid-connect/auth',
+      )
+      expect(config.tokenUrl).toBe(
+        'https://runtime.example.com/realms/example/protocol/openid-connect/token',
+      )
+      expect(config.userInfoUrl).toBe(
+        'https://runtime.example.com/realms/example/protocol/openid-connect/userinfo',
+      )
+      expect(config.logoutUrl).toBe(
+        'https://runtime.example.com/realms/example/protocol/openid-connect/logout',
+      )
+      expect(validateProviderConfig(config).valid).toBe(true)
+    })
+
+    it('keeps omitted preset keys available for Nuxt runtime environment overrides', () => {
+      const inlineRuntimeProvider = createProviderRuntimeConfig(
+        {
+          baseUrl: 'https://configured.example.com/realms/example',
+          clientId: 'configured-client',
+          clientSecret: 'configured-secret',
+          redirectUri: 'https://app.example.com/auth/keycloak/callback',
+        },
+        keycloak,
+      )
+      expect(Object.hasOwn(inlineRuntimeProvider, 'authorizationUrl')).toBe(true)
+
+      const environmentResolvedProvider = {
+        ...inlineRuntimeProvider,
+        authorizationUrl: 'https://runtime.example.com/authorize',
+      }
+      const config = resolveProviderConfig(environmentResolvedProvider, keycloak)
+
+      expect(config.authorizationUrl).toBe('https://runtime.example.com/authorize')
+      expect(config.tokenUrl).toBe(
+        'https://configured.example.com/realms/example/protocol/openid-connect/token',
+      )
+    })
+
+    it('keeps omitted callback redirects distinct from explicit defaults', () => {
+      const omittedRuntimeProvider = createProviderRuntimeConfig({}, oidc)
+      const explicitRuntimeProvider = createProviderRuntimeConfig(
+        { callbackRedirectUrl: '/' },
+        oidc,
+      )
+
+      expect(omittedRuntimeProvider.callbackRedirectUrl).toBeNull()
+      expect(
+        resolveCallbackRedirectUrl({
+          configuredCallbackRedirectUrl: resolveProviderConfig(omittedRuntimeProvider, oidc)
+            .callbackRedirectUrl,
+          hasConfiguredCallbackRedirectUrl:
+            typeof omittedRuntimeProvider.callbackRedirectUrl === 'string',
+          sessionCallbackRedirectUrl: '/protected',
+        }),
+      ).toBe('/protected')
+      expect(
+        resolveCallbackRedirectUrl({
+          configuredCallbackRedirectUrl: resolveProviderConfig(explicitRuntimeProvider, oidc)
+            .callbackRedirectUrl,
+          hasConfiguredCallbackRedirectUrl:
+            typeof explicitRuntimeProvider.callbackRedirectUrl === 'string',
+          sessionCallbackRedirectUrl: '/protected',
+        }),
+      ).toBe('/')
+    })
+
+    it('keeps explicit endpoint overrides ahead of derived endpoints', () => {
+      const config = resolveProviderConfig(
+        {
+          baseUrl: 'https://runtime.example.com/realms/example',
+          clientId: 'runtime-client',
+          clientSecret: 'runtime-secret',
+          redirectUri: 'https://app.example.com/auth/keycloak/callback',
+          authorizationUrl: 'https://login.example.com/authorize',
+          tokenUrl: 'https://login.example.com/token',
+        },
+        keycloak,
+      )
+
+      expect(config.authorizationUrl).toBe('https://login.example.com/authorize')
+      expect(config.tokenUrl).toBe('https://login.example.com/token')
+    })
+
+    it('accepts an omitted client secret for providers that send no client authentication', () => {
+      const config = resolveProviderConfig(
+        {
+          baseUrl: 'https://issuer.example.com',
+          clientId: 'public-client',
+          redirectUri: 'https://app.example.com/auth/zitadel/callback',
+        },
+        zitadel,
+      )
+
+      expect(config.authenticationScheme).toBe('none')
+      expect(validateProviderConfig(config)).toMatchObject({ valid: true, missingProperties: [] })
+    })
+
+    it('rejects unresolved values after defaults and runtime config are resolved', () => {
+      const config = resolveProviderConfig(
+        {
+          baseUrl: '   ',
+          clientId: '',
+          redirectUri: 'https://app.example.com/auth/keycloak/callback',
+        },
+        keycloak,
+      )
+
+      expect(validateProviderConfig(config)).toMatchObject({
+        valid: false,
+        missingProperties: expect.arrayContaining(['baseUrl', 'clientId', 'clientSecret']),
+      })
+    })
+
+    it('does not mutate provider preset parameters between resolutions', () => {
+      const first = resolveProviderConfig(
+        {
+          baseUrl: 'https://first.example.com',
+          clientId: 'first-client',
+          redirectUri: 'https://app.example.com/auth/zitadel/callback',
+        },
+        zitadel,
+      )
+      const second = resolveProviderConfig(
+        {
+          baseUrl: 'https://second.example.com',
+          clientId: 'second-client',
+          redirectUri: 'https://app.example.com/auth/zitadel/callback',
+        },
+        zitadel,
+      )
+
+      expect(first.additionalLogoutParameters?.clientId).toBe('first-client')
+      expect(second.additionalLogoutParameters?.clientId).toBe('second-client')
+      expect(zitadel.additionalLogoutParameters?.clientId).toBe('{clientId}')
     })
   })
 
@@ -207,21 +372,19 @@ describe('configuration Utilities', () => {
       expect(snakeCase('singleSignOutIdField')).toBe('single_sign_out_id_field')
     })
 
-    it('should use snake_case env var names for injected parameters', () => {
-      process.env.NUXT_OIDC_PROVIDERS_OIDC_CLIENT_ID = 'env-client-id'
-
-      const providerOptions = {} as Parameters<typeof replaceInjectedParameters>[1]
+    it('should use values from resolved provider config for injected parameters', () => {
+      const providerOptions = {
+        clientId: 'runtime-client-id',
+      } as Parameters<typeof replaceInjectedParameters>[1]
       const providerPreset = {
         additionalAuthParameters: {
           audience: '{clientId}',
         },
       } as Parameters<typeof replaceInjectedParameters>[2]
 
-      replaceInjectedParameters(['clientId'], providerOptions, providerPreset, 'oidc')
+      replaceInjectedParameters(['clientId'], providerOptions, providerPreset)
 
-      expect(providerOptions.additionalAuthParameters?.audience).toBe('env-client-id')
-
-      delete process.env.NUXT_OIDC_PROVIDERS_OIDC_CLIENT_ID
+      expect(providerOptions.additionalAuthParameters?.audience).toBe('runtime-client-id')
     })
   })
 })

--- a/test/unit/utils/config.test.ts
+++ b/test/unit/utils/config.test.ts
@@ -8,9 +8,10 @@
 
 import { defu } from 'defu'
 import { describe, expect, it } from 'vitest'
-import { keycloak, oidc, zitadel } from '../../../src/runtime/providers'
+import { github, keycloak, oidc, zitadel } from '../../../src/runtime/providers'
 import {
   createProviderRuntimeConfig,
+  hasExplicitProviderConfig,
   replaceInjectedParameters,
   resolveProviderConfig,
   validateConfig,
@@ -238,13 +239,15 @@ describe('configuration Utilities', () => {
         oidc,
       )
 
-      expect(omittedRuntimeProvider.callbackRedirectUrl).toBeNull()
+      expect(hasExplicitProviderConfig(omittedRuntimeProvider, 'callbackRedirectUrl')).toBe(false)
       expect(
         resolveCallbackRedirectUrl({
           configuredCallbackRedirectUrl: resolveProviderConfig(omittedRuntimeProvider, oidc)
             .callbackRedirectUrl,
-          hasConfiguredCallbackRedirectUrl:
-            typeof omittedRuntimeProvider.callbackRedirectUrl === 'string',
+          hasConfiguredCallbackRedirectUrl: hasExplicitProviderConfig(
+            omittedRuntimeProvider,
+            'callbackRedirectUrl',
+          ),
           sessionCallbackRedirectUrl: '/protected',
         }),
       ).toBe('/protected')
@@ -252,8 +255,10 @@ describe('configuration Utilities', () => {
         resolveCallbackRedirectUrl({
           configuredCallbackRedirectUrl: resolveProviderConfig(explicitRuntimeProvider, oidc)
             .callbackRedirectUrl,
-          hasConfiguredCallbackRedirectUrl:
-            typeof explicitRuntimeProvider.callbackRedirectUrl === 'string',
+          hasConfiguredCallbackRedirectUrl: hasExplicitProviderConfig(
+            explicitRuntimeProvider,
+            'callbackRedirectUrl',
+          ),
           sessionCallbackRedirectUrl: '/protected',
         }),
       ).toBe('/')
@@ -277,17 +282,46 @@ describe('configuration Utilities', () => {
     })
 
     it('accepts an omitted client secret for providers that send no client authentication', () => {
-      const config = resolveProviderConfig(
-        {
-          baseUrl: 'https://issuer.example.com',
-          clientId: 'public-client',
-          redirectUri: 'https://app.example.com/auth/zitadel/callback',
-        },
-        zitadel,
-      )
+      const runtimeProvider = {
+        ...createProviderRuntimeConfig({}, zitadel),
+        baseUrl: 'https://issuer.example.com',
+        clientId: 'public-client',
+        redirectUri: 'https://app.example.com/auth/zitadel/callback',
+      }
+      const config = resolveProviderConfig(runtimeProvider, zitadel)
 
       expect(config.authenticationScheme).toBe('none')
+      expect(config.pkce).toBe(true)
+      expect(config.sessionConfiguration?.automaticRefresh).toBe(true)
       expect(validateProviderConfig(config)).toMatchObject({ valid: true, missingProperties: [] })
+    })
+
+    it('restores provider defaults after runtime config serialization', () => {
+      const serializedRuntimeProvider = JSON.parse(
+        JSON.stringify(
+          createProviderRuntimeConfig(
+            {
+              baseUrl: 'https://issuer.example.com',
+              clientId: 'public-client',
+              redirectUri: 'https://app.example.com/auth/zitadel/callback',
+            },
+            zitadel,
+          ),
+        ),
+      ) as Parameters<typeof resolveProviderConfig>[0]
+      const config = resolveProviderConfig(serializedRuntimeProvider, zitadel)
+
+      expect(config.requiredProperties).toEqual(expect.any(Array))
+      expect(config.authenticationScheme).toBe('none')
+      expect(config.pkce).toBe(true)
+      expect(config.sessionConfiguration?.automaticRefresh).toBe(true)
+      expect(validateProviderConfig(config).valid).toBe(true)
+    })
+
+    it('preserves explicit empty optional endpoint overrides', () => {
+      const config = resolveProviderConfig({ userInfoUrl: '' }, github)
+
+      expect(config.userInfoUrl).toBe('')
     })
 
     it('rejects unresolved values after defaults and runtime config are resolved', () => {


### PR DESCRIPTION
## Summary

- resolve provider presets, explicit configuration, and Nuxt runtime environment overrides before endpoint derivation and validation
- require client secrets only for authentication schemes that send them
- add a provider-agnostic in-process handler harness for login, callback, logout, cookie, session, storage, and JWKS flows
- remove the vacuous `test:e2e:oidc` script and document functional tests

## Root cause

Provider endpoints were derived from build-time values in `src/module.ts`, before Nitro runtime overrides were available. Validation therefore rejected placeholders too early and runtime-only `baseUrl` values could not reach derived endpoints. Existing tests also lacked handler-level request, cookie, session, storage, and JWKS coverage.

## Validation

- `pnpm test` — 138/138 passed
- `pnpm typecheck` — passed
- `pnpm fmt:check` — passed
- `pnpm lint` — passed with 24 existing Vitest mock-typing warnings
- `pnpm prepack` — module build and static client generation passed
- independent blank-context xhigh Vue/Nuxt review — VERIFIED

Closes #168
Closes #185