### PR TITLE
fix(auth): add strict token validation

### DIFF
--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -67,7 +67,7 @@ ID and access token validation involves verifying the integrity and claims of th
 We use the well known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
-- ID tokens use configured `clientId`.
+- ID tokens use configured `clientId` and require `sub`, `iat`, and a matching request nonce when nonce is enabled. Present `azp` must match `clientId`, and multi-audience ID tokens require it.
 
 Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -64,11 +64,15 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well known and tested jose library for token validation.
-Tokens will only be validated if the `clientId` or the optional audience (`aud`) field is part of the access_token (or id_token if existent) audiences.
+We use the well known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT token without trusting its decoded claims first. Strict mode verifies signature, expiration, issuer, and token-specific audience:
+
+- Access tokens use configured `audience`.
+- ID tokens use configured `clientId`.
+
+Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-Even if `validateAccessToken` or `validateIdToken` is set, but the audience doesn't match, the token should not and will not be validated.
+`legacy` remains default for current production line. It validates enabled tokens only when decoded `aud` exactly equals configured audience or client ID, and emits one migration warning per provider when validation is skipped. Migrate providers issuing JWTs to `strict` after configuring required audience and discovery metadata. `strict` is intended to become default in next explicitly breaking release.
 ::
 
-Some providers like Entra or Zitadel don't or just in certain cases provide a parsable JWT access token. Validation will fail for these and should be disable, even if the audience is set.
+Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently.

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -64,7 +64,7 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT token without trusting its decoded claims first. Strict mode verifies signature, expiration, issuer, and token-specific audience:
+We use the well known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
 - ID tokens use configured `clientId`.
@@ -74,5 +74,7 @@ Strict access-token validation requires `audience`. Any enabled strict validatio
 ::callout{icon="i-carbon-warning-alt" color="amber"}
 `legacy` remains default for current production line. It validates enabled tokens only when decoded `aud` exactly equals configured audience or client ID, and emits one migration warning per provider when validation is skipped. Migrate providers issuing JWTs to `strict` after configuring required audience and discovery metadata. `strict` is intended to become default in next explicitly breaking release.
 ::
+
+Refresh responses are not yet covered by `tokenValidationMode`; refreshed tokens retain existing parsing behavior until strict refresh validation is delivered.
 
 Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently.

--- a/docs/content/2.provider/1.index.md
+++ b/docs/content/2.provider/1.index.md
@@ -29,7 +29,7 @@ Nuxt OIDC Auth includes presets for the following providers with tested default 
 Some providers have specific additional fields that can be used to extend the authorization, logout or token request. These fields are available via. `additionalAuthParameters`, `additionalLogoutParameters` or `additionalTokenParameters` in the provider configuration.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-Tokens will only be validated if the `clientId` or the optional `audience` field is part of the access_tokens (or id_token if existent) audiences. Even if `validateAccessToken` or `validateIdToken` is set, if the audience doesn't match, the token should not and will not be validated. Some providers like Entra or Zitadel don't or just in certain cases provide a parsable JWT access token. Validation will fail for these and should be disable, even if the audience is set.
+In legacy mode, enabled token validation runs only when decoded token audiences match `clientId` or configured `audience`. Strict mode validates every enabled JWT token with token-specific audience rules. Providers issuing opaque access tokens require explicit validation and parsing opt-outs. See [security guidance](/getting-started/security#token-validation) for migration details.
 ::
 
 The `redirectUri` property is always required and should always point to the callback uri of the specific provider. For Auth0 it should look like this `https://YOURDOMAIN/auth/auth0/callback`. The playgrounds nuxt.config.ts has examples for multiple providers.

--- a/docs/content/2.provider/1.index.md
+++ b/docs/content/2.provider/1.index.md
@@ -29,7 +29,7 @@ Nuxt OIDC Auth includes presets for the following providers with tested default 
 Some providers have specific additional fields that can be used to extend the authorization, logout or token request. These fields are available via. `additionalAuthParameters`, `additionalLogoutParameters` or `additionalTokenParameters` in the provider configuration.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-In legacy mode, enabled token validation runs only when decoded token audiences match `clientId` or configured `audience`. Strict mode validates every enabled JWT token with token-specific audience rules. Providers issuing opaque access tokens require explicit validation and parsing opt-outs. See [security guidance](/getting-started/security#token-validation) for migration details.
+In legacy mode, enabled callback token validation runs only when decoded token audiences match `clientId` or configured `audience`. Strict mode validates every enabled JWT in the initial callback token response with token-specific audience rules. Providers issuing opaque access tokens require explicit validation and parsing opt-outs. See [security guidance](/getting-started/security#token-validation) for migration details.
 ::
 
 The `redirectUri` property is always required and should always point to the callback uri of the specific provider. For Auth0 it should look like this `https://YOURDOMAIN/auth/auth0/callback`. The playgrounds nuxt.config.ts has examples for multiple providers.

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -76,6 +76,7 @@ export default defineNuxtConfig({
 | openIdConfiguration | `Record<string, unknown>` or `function (config) => Promise<Record<string, unknown>>` (optional) | `undefined` | OpenID Configuration object or function that resolves to an OpenID Configuration object. |
 | validateAccessToken | `boolean` (optional) | `true` | Validate access token. |
 | validateIdToken | `boolean` (optional) | `true` | Validate id token. |
+| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT token with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. |
 | encodeRedirectUri | `boolean` (optional) | `false` | Encode redirect uri query parameter in authorization request. Only for compatibility with services that don't implement proper parsing of query parameters. |
 | exposeAccessToken | `boolean` (optional) | `false` | Expose access token to the client within session object |
 | exposeIdToken | `boolean` (optional) | `false` | Expose raw id token to the client within session object |

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -76,7 +76,7 @@ export default defineNuxtConfig({
 | openIdConfiguration | `Record<string, unknown>` or `function (config) => Promise<Record<string, unknown>>` (optional) | `undefined` | OpenID Configuration object or function that resolves to an OpenID Configuration object. |
 | validateAccessToken | `boolean` (optional) | `true` | Validate access token. |
 | validateIdToken | `boolean` (optional) | `true` | Validate id token. |
-| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT token with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. |
+| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT in the initial callback token response with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. Refresh responses retain existing parsing behavior until strict refresh validation is delivered. |
 | encodeRedirectUri | `boolean` (optional) | `false` | Encode redirect uri query parameter in authorization request. Only for compatibility with services that don't implement proper parsing of query parameters. |
 | exposeAccessToken | `boolean` (optional) | `false` | Expose access token to the client within session object |
 | exposeIdToken | `boolean` (optional) | `false` | Expose raw id token to the client within session object |

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -58,6 +58,22 @@ function isStrictIssuer(value: unknown): value is string | string[] {
   )
 }
 
+async function validateOidcIdToken(
+  token: string,
+  options: Parameters<typeof validateToken>[1],
+  clientId: string,
+): Promise<JwtPayload> {
+  const payload = await validateToken(token, options)
+  if (
+    Array.isArray(payload.aud) &&
+    payload.aud.length > 1 &&
+    (typeof payload.azp !== 'string' || payload.azp !== clientId)
+  ) {
+    throw new Error('ID token with multiple audiences requires azp matching clientId')
+  }
+  return payload
+}
+
 function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
@@ -258,10 +274,16 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
           ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
           ...(tokenResponse.id_token && {
             idToken: validateIdToken
-              ? await validateToken(tokenResponse.id_token, {
-                  ...commonValidationOptions,
-                  ...(strictValidation ? { audience: config.clientId } : legacyAudience),
-                })
+              ? strictValidation
+                ? await validateOidcIdToken(
+                    tokenResponse.id_token,
+                    { ...commonValidationOptions, audience: config.clientId },
+                    config.clientId,
+                  )
+                : await validateToken(tokenResponse.id_token, {
+                    ...commonValidationOptions,
+                    ...legacyAudience,
+                  })
               : idToken,
           }),
         }

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -294,7 +294,7 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
                     { ...commonValidationOptions, audience: config.clientId },
                     config.clientId,
                     session.data.nonce,
-                    config.nonce,
+                    config.nonce || config.responseType.includes('token'),
                   )
                 : await validateToken(tokenResponse.id_token, {
                     ...commonValidationOptions,

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -62,14 +62,28 @@ async function validateOidcIdToken(
   token: string,
   options: Parameters<typeof validateToken>[1],
   clientId: string,
+  expectedNonce?: string,
+  nonceRequired = false,
 ): Promise<JwtPayload> {
-  const payload = await validateToken(token, options)
+  const payload = await validateToken(token, {
+    ...options,
+    requiredClaims: [...new Set([...(options.requiredClaims || []), 'sub', 'iat'])],
+  })
+  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+    throw new Error('ID token sub must be a non-empty string')
+  }
+  const authorizedParty = payload.azp
   if (
-    Array.isArray(payload.aud) &&
-    payload.aud.length > 1 &&
-    (typeof payload.azp !== 'string' || payload.azp !== clientId)
+    (Array.isArray(payload.aud) && payload.aud.length > 1 && typeof authorizedParty !== 'string') ||
+    (authorizedParty !== undefined && authorizedParty !== clientId)
   ) {
-    throw new Error('ID token with multiple audiences requires azp matching clientId')
+    throw new Error('ID token azp must match clientId and is required for multiple audiences')
+  }
+  if (nonceRequired && (typeof expectedNonce !== 'string' || expectedNonce.length === 0)) {
+    throw new Error('Authentication session is missing the expected nonce')
+  }
+  if (nonceRequired && payload.nonce !== expectedNonce) {
+    throw new Error('ID token nonce must match the authentication request')
   }
   return payload
 }
@@ -279,6 +293,8 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
                     tokenResponse.id_token,
                     { ...commonValidationOptions, audience: config.clientId },
                     config.clientId,
+                    session.data.nonce,
+                    config.nonce,
                   )
                 : await validateToken(tokenResponse.id_token, {
                     ...commonValidationOptions,

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -32,6 +32,32 @@ import { resolveCallbackRedirectUrl } from '../utils/redirect'
 import { encryptToken, parseJwtToken, validateToken } from '../utils/security'
 import { getUserSessionId, setUserSession, useAuthSession } from '../utils/session'
 
+const warnedLegacyValidationProviders = new Set<ProviderKeys>()
+
+function hasExactAudience(payload: JwtPayload | undefined, expectedAudiences: string[]): boolean {
+  if (typeof payload?.aud === 'string') return expectedAudiences.includes(payload.aud)
+  if (!Array.isArray(payload?.aud)) return false
+  return payload.aud.some(
+    (audience) => typeof audience === 'string' && expectedAudiences.includes(audience),
+  )
+}
+
+function isIssuer(value: unknown): value is string | string[] {
+  return (
+    typeof value === 'string' ||
+    (Array.isArray(value) && value.every((issuer) => typeof issuer === 'string'))
+  )
+}
+
+function isStrictIssuer(value: unknown): value is string | string[] {
+  return (
+    (typeof value === 'string' && value.trim().length > 0) ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((issuer) => typeof issuer === 'string' && issuer.trim().length > 0))
+  )
+}
+
 function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
@@ -47,7 +73,9 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
 
     if (!validationResult.valid) {
       logger.error(
-        `[${provider}] Missing or empty configuration properties:`,
+        config.tokenValidationMode === 'strict'
+          ? `[${provider}] Strict token validation requires non-empty configuration properties:`
+          : `[${provider}] Missing or empty configuration properties:`,
         validationResult.missingProperties?.join(', '),
       )
       return oidcErrorHandler(event, 'Invalid configuration')
@@ -161,7 +189,6 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
     // Initialize tokens object
     let tokens: Tokens
 
-    // Validate tokens only if audience is matched
     let accessToken: JwtPayload | Record<string, never>
     let idToken: JwtPayload | Record<string, never> | undefined
     if (!tokenResponse.access_token)
@@ -172,46 +199,93 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
     } catch (error) {
       return oidcErrorHandler(event, `[${provider}] Token parsing failed: ${String(error)}`)
     }
-    if (
-      [config.audience as string, config.clientId].some(
-        (audience) => accessToken.aud?.includes(audience) || idToken?.aud?.includes(audience),
-      ) &&
-      (config.validateAccessToken || config.validateIdToken)
-    ) {
-      // Get OIDC configuration
-      const openIdConfiguration =
-        config.openIdConfiguration && typeof config.openIdConfiguration === 'object'
-          ? config.openIdConfiguration
-          : typeof config.openIdConfiguration === 'string'
-            ? await customFetch(config.openIdConfiguration)
-            : await config.openIdConfiguration!(config)
-      const validationOptions = {
-        jwksUri: openIdConfiguration.jwks_uri as string,
-        ...(openIdConfiguration.issuer && { issuer: openIdConfiguration.issuer as string }),
-        ...(config.audience && { audience: [config.audience, config.clientId] }),
-      }
+
+    const strictValidation = config.tokenValidationMode === 'strict'
+    if (strictValidation && config.validateIdToken && !tokenResponse.id_token) {
+      return oidcErrorHandler(event, `[${provider}] Token validation failed: Missing ID token`)
+    }
+
+    const legacyAudiences = [config.audience, config.clientId].filter(
+      (audience): audience is string => !!audience,
+    )
+    const legacyAudienceMatched =
+      !strictValidation &&
+      (hasExactAudience(accessToken, legacyAudiences) || hasExactAudience(idToken, legacyAudiences))
+    const validateAccessToken =
+      !!config.validateAccessToken && (strictValidation || legacyAudienceMatched)
+    const validateIdToken =
+      !!config.validateIdToken &&
+      !!tokenResponse.id_token &&
+      (strictValidation || legacyAudienceMatched)
+
+    if (validateAccessToken || validateIdToken) {
       try {
+        const openIdConfiguration =
+          config.openIdConfiguration && typeof config.openIdConfiguration === 'object'
+            ? config.openIdConfiguration
+            : typeof config.openIdConfiguration === 'string'
+              ? await customFetch(config.openIdConfiguration)
+              : await config.openIdConfiguration!(config)
+        const issuer = openIdConfiguration.issuer
+        const jwksUri = openIdConfiguration.jwks_uri
+        if (
+          strictValidation &&
+          (!isStrictIssuer(issuer) || typeof jwksUri !== 'string' || !jwksUri)
+        ) {
+          throw new Error('Strict token validation requires discovery issuer and jwks_uri')
+        }
+        if (!strictValidation && issuer && !isIssuer(issuer)) {
+          throw new Error('OpenID configuration has invalid issuer metadata')
+        }
+        if (typeof jwksUri !== 'string' || !jwksUri) {
+          throw new Error('OpenID configuration is missing jwks_uri')
+        }
+        const commonValidationOptions = {
+          jwksUri,
+          ...((strictValidation ? isStrictIssuer(issuer) : isIssuer(issuer)) && { issuer }),
+          ...(strictValidation && { requiredClaims: ['exp'] }),
+        }
+        const legacyAudience = config.audience
+          ? { audience: [config.audience, config.clientId] }
+          : {}
         tokens = {
-          accessToken: config.validateAccessToken
-            ? await validateToken(tokenResponse.access_token, validationOptions)
+          accessToken: validateAccessToken
+            ? await validateToken(tokenResponse.access_token, {
+                ...commonValidationOptions,
+                ...(strictValidation ? { audience: config.audience } : legacyAudience),
+              })
             : accessToken,
           ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
           ...(tokenResponse.id_token && {
-            idToken: config.validateIdToken
-              ? await validateToken(tokenResponse.id_token, validationOptions)
-              : parseJwtToken(tokenResponse.id_token),
+            idToken: validateIdToken
+              ? await validateToken(tokenResponse.id_token, {
+                  ...commonValidationOptions,
+                  ...(strictValidation ? { audience: config.clientId } : legacyAudience),
+                })
+              : idToken,
           }),
         }
       } catch (error) {
         return oidcErrorHandler(event, `[${provider}] Token validation failed: ${String(error)}`)
       }
     } else {
-      logger.info('Skipped token validation')
       tokens = {
         accessToken,
         ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
-        ...(tokenResponse.id_token && { idToken: parseJwtToken(tokenResponse.id_token) }),
+        ...(idToken && { idToken }),
       }
+    }
+
+    if (
+      !strictValidation &&
+      ((config.validateAccessToken && !validateAccessToken) ||
+        (config.validateIdToken && !validateIdToken)) &&
+      !warnedLegacyValidationProviders.has(provider)
+    ) {
+      warnedLegacyValidationProviders.add(provider)
+      logger.warn(
+        `[${provider}] Legacy token validation skipped an enabled token because no token audience matched or the token was unavailable. Configure tokenValidationMode: 'strict' to validate enabled JWT tokens without trusting decoded claims.`,
+      )
     }
 
     // Construct user object

--- a/src/runtime/server/utils/config.ts
+++ b/src/runtime/server/utils/config.ts
@@ -186,15 +186,33 @@ export function resolveProviderConfig(
 }
 
 export function getRequiredProviderProperties(config: OidcProviderConfig): string[] {
-  return config.requiredProperties.filter(
+  const requiredProperties = config.requiredProperties.filter(
     (property) => property !== 'clientSecret' || config.authenticationScheme !== 'none',
   )
+  if (config.tokenValidationMode === 'strict') {
+    if (config.validateAccessToken) requiredProperties.push('audience')
+    if (config.validateAccessToken || config.validateIdToken) {
+      requiredProperties.push('openIdConfiguration')
+    }
+  }
+  return [...new Set(requiredProperties)]
 }
 
 export function validateProviderConfig(
   config: OidcProviderConfig,
 ): ValidationResult<OidcProviderConfig> {
-  return validateConfig(config, getRequiredProviderProperties(config))
+  const result = validateConfig(config, getRequiredProviderProperties(config))
+  if (
+    config.tokenValidationMode !== undefined &&
+    config.tokenValidationMode !== 'legacy' &&
+    config.tokenValidationMode !== 'strict'
+  ) {
+    result.valid = false
+    result.missingProperties = [
+      ...new Set([...(result.missingProperties || []), 'tokenValidationMode']),
+    ]
+  }
+  return result
 }
 
 export function replaceInjectedParameters(

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -161,6 +161,11 @@ export interface OidcProviderConfig {
    */
   validateIdToken?: boolean
   /**
+   * Token validation behavior. Strict mode validates every enabled JWT token without trusting decoded claims first.
+   * @default 'legacy'
+   */
+  tokenValidationMode?: 'legacy' | 'strict'
+  /**
    * Provider Only. Base URL for the provider, used when to dynamically create authorizationUrl, tokenUrl, userinfoUrl and logoutUrl if possible
    */
   baseUrl?: string
@@ -267,6 +272,7 @@ export function defineOidcProvider<
     requiredProperties: ['clientId', 'redirectUri', 'clientSecret', 'authorizationUrl', 'tokenUrl'],
     validateAccessToken: true,
     validateIdToken: true,
+    tokenValidationMode: 'legacy',
     skipAccessTokenParsing: false,
     exposeAccessToken: false,
     exposeIdToken: false,

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -161,7 +161,7 @@ export interface OidcProviderConfig {
    */
   validateIdToken?: boolean
   /**
-   * Token validation behavior. Strict mode validates every enabled JWT token without trusting decoded claims first.
+   * Callback token validation behavior. Strict mode validates every enabled JWT in the initial token response without trusting decoded claims first.
    * @default 'legacy'
    */
   tokenValidationMode?: 'legacy' | 'strict'

--- a/src/runtime/server/utils/security.ts
+++ b/src/runtime/server/utils/security.ts
@@ -63,9 +63,10 @@ export interface EncryptedToken {
 }
 
 export interface ValidateAccessTokenOptions {
-  issuer: string | string[]
+  issuer?: string | string[]
   jwksUri: string
   audience?: string | string[]
+  requiredClaims?: string[]
 }
 
 const unreservedCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'
@@ -229,6 +230,7 @@ export async function validateToken(
   const { payload } = await jwtVerify(token, jwks, {
     issuer: options.issuer,
     audience: options.audience,
+    requiredClaims: options.requiredClaims,
   })
   return payload as JwtPayload
 }

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -316,6 +316,72 @@ describe('callback token validation', () => {
     expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
   })
 
+  it.each([
+    { name: 'missing', azp: undefined, accepted: false },
+    { name: 'different', azp: 'another-client', accepted: false },
+    { name: 'matching', azp: 'functional-client', accepted: true },
+  ])('$name azp for strict multi-audience ID tokens', async ({ accepted, azp }) => {
+    const idToken = await signingFixture.sign({
+      aud: ['functional-client', 'another-audience'],
+      ...(azp && { azp }),
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      accepted ? expect.objectContaining({ provider: 'oidc' }) : {},
+    )
+  })
+
+  it('preserves legacy multi-audience ID tokens without azp', async () => {
+    const idToken = await signingFixture.sign({
+      aud: ['functional-client', 'another-audience'],
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        tokenValidationMode: 'legacy',
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+  })
+
   it('fails strict validation when enabled ID token is missing', async () => {
     const harness = new HandlerHarness({
       runtimeConfig: createStrictRuntimeConfig({

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -1,12 +1,34 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import type * as OidcUtils from '../../src/runtime/server/utils/oidc'
+import { importJWK, SignJWT } from 'jose'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
 
 const tokenUrl = 'https://identity.example.test/token'
+const issuer = 'https://identity.example.test'
+const jwksUri = `${issuer}/jwks`
 let accessToken: string
+let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+
+const testLogger = vi.hoisted(() => ({
+  error: vi.fn<(...args: unknown[]) => void>(),
+  info: vi.fn<(...args: unknown[]) => void>(),
+  warn: vi.fn<(...args: unknown[]) => void>(),
+}))
+
+vi.mock('../../src/runtime/server/utils/oidc', async (importOriginal) => {
+  const actual = await importOriginal<typeof OidcUtils>()
+  return { ...actual, useOidcLogger: () => testLogger }
+})
 
 beforeAll(async () => {
-  const fixture = await createRs256Fixture()
-  accessToken = await fixture.sign({ aud: 'functional-client', sub: 'user-1' })
+  signingFixture = await createRs256Fixture()
+  accessToken = await signingFixture.sign({ aud: 'functional-client', sub: 'user-1' })
+})
+
+beforeEach(() => {
+  testLogger.error.mockClear()
+  testLogger.info.mockClear()
+  testLogger.warn.mockClear()
 })
 
 afterEach(() => {
@@ -42,6 +64,59 @@ function createRuntimeConfig(callbackRedirectUrl?: string) {
       },
     },
   }
+}
+
+function createStrictRuntimeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    oidc: {
+      session: {
+        maxAge: 3600,
+        automaticRefresh: false,
+        expirationCheck: false,
+      },
+      providers: {
+        oidc: {
+          clientId: 'functional-client',
+          clientSecret: 'functional-secret',
+          authorizationUrl: `${issuer}/authorize`,
+          tokenUrl,
+          redirectUri: 'https://app.example.test/auth/oidc/callback',
+          audience: 'functional-api',
+          tokenValidationMode: 'strict',
+          validateAccessToken: true,
+          validateIdToken: false,
+          openIdConfiguration: { issuer, jwks_uri: jwksUri },
+          requiredProperties: [
+            'clientId',
+            'clientSecret',
+            'authorizationUrl',
+            'tokenUrl',
+            'redirectUri',
+          ],
+          ...overrides,
+        },
+      },
+    },
+  }
+}
+
+function seedCallbackSession(harness: HandlerHarness) {
+  harness.cookieJar.seedSession('oidc', {
+    state: 'functional-state',
+    nonce: 'functional-nonce',
+    codeVerifier: 'functional-code-verifier',
+    redirect: 'https://app.example.test/auth/oidc/callback',
+  })
+}
+
+async function invokeCallback(harness: HandlerHarness) {
+  const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+  const request = harness.createEvent({
+    path: '/auth/oidc/callback',
+    query: { code: 'functional-code', state: 'functional-state' },
+  })
+  await callbackHandler(request.event)
+  return request
 }
 
 describe('callback handler redirects', () => {
@@ -185,5 +260,380 @@ describe('callback handler redirects', () => {
     expect(tokenRequestBody?.get('client_id')).toBe('functional-client')
     expect(tokenRequestBody?.get('code_verifier')).toBe('functional-code-verifier')
     expect(tokenRequestBody?.has('client_secret')).toBe(false)
+  })
+})
+
+describe('callback token validation', () => {
+  it('validates strict access tokens even when their decoded audience does not match', async () => {
+    const wrongAudienceToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({ runtimeConfig: createStrictRuntimeConfig() })
+    seedCallbackSession(harness)
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: wrongAudienceToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(interceptor.requests.map((request) => request.url)).toContain(jwksUri)
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('validates enabled ID tokens independently from disabled access-token validation', async () => {
+    const idToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+  })
+
+  it('fails strict validation when enabled ID token is missing', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: accessToken, token_type: 'Bearer' }),
+      },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(interceptor.requests).toHaveLength(1)
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('requires exp in strict mode', async () => {
+    const privateKey = await importJWK(signingFixture.privateJwk, 'RS256')
+    const tokenWithoutExpiration = await new SignJWT({
+      aud: 'functional-api',
+      iss: issuer,
+      sub: 'user-1',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: signingFixture.privateJwk.kid })
+      .setIssuedAt()
+      .sign(privateKey)
+    const harness = new HandlerHarness({ runtimeConfig: createStrictRuntimeConfig() })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: tokenWithoutExpiration, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it.each([
+    { name: 'issuer', openIdConfiguration: { jwks_uri: jwksUri } },
+    {
+      name: 'non-empty issuer array',
+      openIdConfiguration: { issuer: [issuer, ' '], jwks_uri: jwksUri },
+    },
+    { name: 'jwks_uri', openIdConfiguration: { issuer } },
+  ])('requires discovery $name in strict mode', async ({ openIdConfiguration }) => {
+    const strictAccessToken = await signingFixture.sign({
+      aud: 'functional-api',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({ openIdConfiguration }),
+    })
+    seedCallbackSession(harness)
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: strictAccessToken, token_type: 'Bearer' }),
+      },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(interceptor.requests).toHaveLength(1)
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('accepts strict discovery issuer arrays', async () => {
+    const strictAccessToken = await signingFixture.sign({
+      aud: 'functional-api',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        openIdConfiguration: { issuer: [issuer, `${issuer}/tenant`], jwks_uri: jwksUri },
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: strictAccessToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+  })
+
+  it('preserves legacy issuer arrays when validating tokens', async () => {
+    const wrongIssuerToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: 'https://attacker.example.test',
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        openIdConfiguration: { issuer: [issuer, `${issuer}/tenant`], jwks_uri: jwksUri },
+        tokenValidationMode: 'legacy',
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: wrongIssuerToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('preserves malformed legacy issuer arrays for fail-closed validation', async () => {
+    const wrongIssuerToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: 'https://attacker.example.test',
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        openIdConfiguration: { issuer: [issuer, ' '], jwks_uri: jwksUri },
+        tokenValidationMode: 'legacy',
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: wrongIssuerToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('rejects mixed-type legacy issuer arrays instead of dropping issuer validation', async () => {
+    const matchingToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        openIdConfiguration: {
+          issuer: [issuer, undefined] as unknown as string[],
+          jwks_uri: jwksUri,
+        },
+        tokenValidationMode: 'legacy',
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: matchingToken, token_type: 'Bearer' }),
+      },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('does not inspect malformed decoded audiences before strict validation', async () => {
+    const privateKey = await importJWK(signingFixture.privateJwk, 'RS256')
+    const malformedAudienceToken = await new SignJWT({
+      aud: 42 as unknown as string,
+      iss: issuer,
+      sub: 'user-1',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: signingFixture.privateJwk.kid })
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey)
+    const harness = new HandlerHarness({ runtimeConfig: createStrictRuntimeConfig() })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: malformedAudienceToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await expect(invokeCallback(harness)).resolves.toBeDefined()
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('preserves legacy validation without exp and matches array audiences by exact member', async () => {
+    const privateKey = await importJWK(signingFixture.privateJwk, 'RS256')
+    const legacyToken = await new SignJWT({
+      aud: ['another-audience', 'functional-client'],
+      iss: issuer,
+      sub: 'user-1',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: signingFixture.privateJwk.kid })
+      .setIssuedAt()
+      .sign(privateKey)
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        tokenValidationMode: 'legacy',
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: legacyToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+  })
+
+  it('preserves shared legacy audience gating for every enabled token type', async () => {
+    const matchingAccessToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const invalidIdToken = await signingFixture.sign({
+      aud: 'unmatched-audience',
+      iss: 'https://attacker.example.test',
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        tokenValidationMode: 'legacy',
+        validateAccessToken: true,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({
+            access_token: matchingAccessToken,
+            id_token: invalidIdToken,
+            token_type: 'Bearer',
+          }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('uses exact legacy string audience matching and warns once per provider', async () => {
+    const similarAudienceToken = await signingFixture.sign({
+      aud: 'prefix-functional-client-suffix',
+      sub: 'user-1',
+    })
+    const runtimeConfig = createRuntimeConfig()
+    runtimeConfig.oidc.providers.oidc.validateAccessToken = true
+
+    for (let requestNumber = 0; requestNumber < 2; requestNumber += 1) {
+      const harness = new HandlerHarness({ runtimeConfig })
+      seedCallbackSession(harness)
+      interceptFetch([
+        {
+          method: 'POST',
+          url: tokenUrl,
+          respond: () =>
+            Response.json({ access_token: similarAudienceToken, token_type: 'Bearer' }),
+        },
+      ])
+      await invokeCallback(harness)
+      expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+    }
+
+    expect(testLogger.warn).toHaveBeenCalledTimes(1)
+    expect(testLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("tokenValidationMode: 'strict'"),
+    )
+    expect(testLogger.warn.mock.calls[0]?.join(' ')).not.toContain(similarAudienceToken)
   })
 })

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -424,6 +424,43 @@ describe('callback token validation', () => {
     )
   })
 
+  it.each([
+    { name: 'different', nonce: 'wrong-nonce', accepted: false },
+    { name: 'matching', nonce: 'functional-nonce', accepted: true },
+  ])('$name generated nonce for strict hybrid ID tokens', async ({ accepted, nonce }) => {
+    const idToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      nonce,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        nonce: false,
+        responseType: 'code id_token',
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      accepted ? expect.objectContaining({ provider: 'oidc' }) : {},
+    )
+  })
+
   it('rejects strict ID tokens when enabled nonce is missing from the auth session', async () => {
     const idToken = await signingFixture.sign({
       aud: 'functional-client',

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -100,10 +100,10 @@ function createStrictRuntimeConfig(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function seedCallbackSession(harness: HandlerHarness) {
+function seedCallbackSession(harness: HandlerHarness, includeNonce = true) {
   harness.cookieJar.seedSession('oidc', {
     state: 'functional-state',
-    nonce: 'functional-nonce',
+    ...(includeNonce && { nonce: 'functional-nonce' }),
     codeVerifier: 'functional-code-verifier',
     redirect: 'https://app.example.test/auth/oidc/callback',
   })
@@ -350,6 +350,177 @@ describe('callback token validation', () => {
     expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
       accepted ? expect.objectContaining({ provider: 'oidc' }) : {},
     )
+  })
+
+  it.each([
+    { name: 'matching', azp: 'functional-client', accepted: true },
+    { name: 'different', azp: 'another-client', accepted: false },
+  ])('$name azp for strict single-audience ID tokens', async ({ accepted, azp }) => {
+    const idToken = await signingFixture.sign({
+      aud: 'functional-client',
+      azp,
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      accepted ? expect.objectContaining({ provider: 'oidc' }) : {},
+    )
+  })
+
+  it.each([
+    { name: 'missing', nonce: undefined, accepted: false },
+    { name: 'different', nonce: 'wrong-nonce', accepted: false },
+    { name: 'matching', nonce: 'functional-nonce', accepted: true },
+  ])('$name nonce for strict ID tokens', async ({ accepted, nonce }) => {
+    const idToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      ...(nonce && { nonce }),
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        nonce: true,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      accepted ? expect.objectContaining({ provider: 'oidc' }) : {},
+    )
+  })
+
+  it('rejects strict ID tokens when enabled nonce is missing from the auth session', async () => {
+    const idToken = await signingFixture.sign({
+      aud: 'functional-client',
+      iss: issuer,
+      nonce: 'functional-nonce',
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        nonce: true,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness, false)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it.each(['sub', 'iat'] as const)('requires %s in strict ID tokens', async (missingClaim) => {
+    const claims = {
+      aud: 'functional-client',
+      exp: Math.trunc(Date.now() / 1000) + 300,
+      iss: issuer,
+      sub: 'user-1',
+      iat: Math.trunc(Date.now() / 1000),
+    }
+    delete claims[missingClaim]
+    const idToken = await new SignJWT(claims)
+      .setProtectedHeader({ alg: 'RS256', kid: signingFixture.privateJwk.kid })
+      .sign(await importJWK(signingFixture.privateJwk, 'RS256'))
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it('requires sub to be a string in strict ID tokens', async () => {
+    const idToken = await new SignJWT({
+      aud: 'functional-client',
+      exp: Math.trunc(Date.now() / 1000) + 300,
+      iat: Math.trunc(Date.now() / 1000),
+      iss: issuer,
+      sub: 42 as unknown as string,
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: signingFixture.privateJwk.kid })
+      .sign(await importJWK(signingFixture.privateJwk, 'RS256'))
+    const harness = new HandlerHarness({
+      runtimeConfig: createStrictRuntimeConfig({
+        audience: undefined,
+        validateAccessToken: false,
+        validateIdToken: true,
+      }),
+    })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, id_token: idToken, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
   })
 
   it('preserves legacy multi-audience ID tokens without azp', async () => {

--- a/test/unit/utils/config.test.ts
+++ b/test/unit/utils/config.test.ts
@@ -191,6 +191,69 @@ describe('configuration Utilities', () => {
   })
 
   describe('resolved provider configuration', () => {
+    it('defaults token validation mode to legacy and preserves runtime overrides', () => {
+      expect(resolveProviderConfig({}, oidc).tokenValidationMode).toBe('legacy')
+      expect(
+        resolveProviderConfig(
+          createProviderRuntimeConfig({ tokenValidationMode: 'strict' }, oidc),
+          oidc,
+        ).tokenValidationMode,
+      ).toBe('strict')
+    })
+
+    it('rejects an invalid runtime token validation mode', () => {
+      const config = resolveProviderConfig({}, oidc)
+      Object.assign(config, { tokenValidationMode: 'unsupported' })
+
+      expect(validateProviderConfig(config)).toMatchObject({
+        valid: false,
+        missingProperties: expect.arrayContaining(['tokenValidationMode']),
+      })
+    })
+
+    it('requires strict access-token audience and discovery configuration', () => {
+      const config = resolveProviderConfig(
+        {
+          clientId: 'strict-client',
+          clientSecret: 'strict-secret',
+          authorizationUrl: 'https://issuer.example.com/authorize',
+          tokenUrl: 'https://issuer.example.com/token',
+          redirectUri: 'https://app.example.com/auth/oidc/callback',
+          tokenValidationMode: 'strict',
+          validateAccessToken: true,
+          validateIdToken: false,
+        },
+        oidc,
+      )
+
+      expect(validateProviderConfig(config)).toMatchObject({
+        valid: false,
+        missingProperties: expect.arrayContaining(['audience', 'openIdConfiguration']),
+      })
+    })
+
+    it('does not require an access-token audience when only strict ID validation is enabled', () => {
+      const config = resolveProviderConfig(
+        {
+          clientId: 'strict-client',
+          clientSecret: 'strict-secret',
+          authorizationUrl: 'https://issuer.example.com/authorize',
+          tokenUrl: 'https://issuer.example.com/token',
+          redirectUri: 'https://app.example.com/auth/oidc/callback',
+          tokenValidationMode: 'strict',
+          validateAccessToken: false,
+          validateIdToken: true,
+          openIdConfiguration: {
+            issuer: 'https://issuer.example.com',
+            jwks_uri: 'https://issuer.example.com/jwks',
+          },
+        },
+        oidc,
+      )
+
+      expect(validateProviderConfig(config)).toMatchObject({ valid: true, missingProperties: [] })
+    })
+
     it('replaces empty configured placeholders with Nuxt runtime overrides before derivation', () => {
       const configuredProvider = {
         baseUrl: '',


### PR DESCRIPTION
## Summary

- add provider-level `tokenValidationMode: 'legacy' | 'strict'` with compatible `legacy` default
- validate every enabled JWT in initial callback token responses through JOSE with issuer, expiry, signature, and token-specific audience checks
- require access-token `audience`, discovery metadata, and enabled ID tokens in strict callback mode
- replace legacy substring matching with exact string/array audience matching and one migration warning per provider
- document strict callback migration, opaque access-token opt-outs, and refresh scope

## Root cause

Callback validation trusted decoded token audiences to decide whether cryptographic validation should run. Nonmatching audiences could route enabled validation into decoded-token acceptance, and string audiences used substring matching. Access and ID tokens also shared one audience list even though access tokens target configured resources while ID tokens target the OIDC client.

## Compatibility

`legacy` remains default. Existing callback audience-gated validation stays intact apart from exact matching and actionable once-per-provider warnings. Strict callback mode is opt-in and preserves issuer-array behavior used by Entra and Microsoft. Opaque access tokens remain supported with `validateAccessToken: false` and `skipAccessTokenParsing: true`.

Refresh responses retain existing parsing behavior. #191 tracks strict refresh-response validation before any future strict-default flip.

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 45/45 passed
- focused callback/config security coverage - 72/72 passed
- `pnpm test:e2e --workers=1` with Nix Chrome - 32 passed, 32 provider-config-gated skipped
- `pnpm prepack` - module build and static client generation passed
- security and Nuxt/Vue reviews - no blockers

Closes #163
Tracks #161
Tracks #191


