### PR TITLE
test(auth): prove strict token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - **auth:** Prevent client overrides of reserved OAuth/OIDC authorization parameters
 - **auth:** Preserve dynamic callback redirects and reject unsafe local redirect paths
+- **auth:** Add strict callback token validation and migration guidance
 - **config:** Allow public PKCE clients to omit client secrets
 
 ## v1.0.0-beta.11

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -64,7 +64,7 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
+We use the well-known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
 - ID tokens use configured `clientId` and require `sub`, `iat`, and a matching request nonce when nonce is enabled. Present `azp` must match `clientId`, and multi-audience ID tokens require it.
@@ -78,3 +78,5 @@ Strict access-token validation requires `audience`. Any enabled strict validatio
 Refresh responses are not yet covered by `tokenValidationMode`; refreshed tokens retain existing parsing behavior until strict refresh validation is delivered.
 
 Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently.
+
+Offline end-to-end tests use the generic `oidc` fixture with access-token and ID-token validation explicitly disabled because its mock provider emits random-string signatures and a placeholder JWKS. Before strict validation becomes default, that fixture must issue tokens and JWKS signed with test key material and enable strict validation.

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -64,7 +64,7 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well-known and tested jose library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
+We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
 - ID tokens use configured `clientId` and require `sub`, `iat`, and a matching request nonce when nonce is enabled. Present `azp` must match `clientId`, and multi-audience ID tokens require it.

--- a/test/fixtures/oidcApp/nuxt.config.ts
+++ b/test/fixtures/oidcApp/nuxt.config.ts
@@ -31,6 +31,9 @@ export default defineNuxtConfig({
         redirectUri: 'http://localhost:3000/auth/oidc/callback',
         scope: ['openid', 'profile', 'email'],
         pkce: true,
+        // Offline mock tokens are parseable JWTs but do not have cryptographic signatures.
+        validateAccessToken: false,
+        validateIdToken: false,
       },
       // Keycloak provider for integration testing (requires running server)
       keycloak: {

--- a/test/fixtures/oidcApp/nuxt.config.ts
+++ b/test/fixtures/oidcApp/nuxt.config.ts
@@ -31,7 +31,7 @@ export default defineNuxtConfig({
         redirectUri: 'http://localhost:3000/auth/oidc/callback',
         scope: ['openid', 'profile', 'email'],
         pkce: true,
-        // Offline mock tokens are parseable JWTs but do not have cryptographic signatures.
+        // Offline mock tokens are parseable JWTs with random, non-cryptographic signatures.
         validateAccessToken: false,
         validateIdToken: false,
       },

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -8,6 +8,7 @@ const issuer = 'https://identity.example.test'
 const jwksUri = `${issuer}/jwks`
 let accessToken: string
 let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+let untrustedSigningFixture: Awaited<ReturnType<typeof createRs256Fixture>>
 
 const testLogger = vi.hoisted(() => ({
   error: vi.fn<(...args: unknown[]) => void>(),
@@ -22,6 +23,7 @@ vi.mock('../../src/runtime/server/utils/oidc', async (importOriginal) => {
 
 beforeAll(async () => {
   signingFixture = await createRs256Fixture()
+  untrustedSigningFixture = await createRs256Fixture()
   accessToken = await signingFixture.sign({ aud: 'functional-client', sub: 'user-1' })
 })
 
@@ -264,6 +266,64 @@ describe('callback handler redirects', () => {
 })
 
 describe('callback token validation', () => {
+  it.each([
+    {
+      name: 'wrong signature',
+      claims: { aud: 'functional-api', iss: issuer, sub: 'user-1' },
+      untrusted: true,
+    },
+    {
+      name: 'expired token',
+      claims: { aud: 'functional-api', exp: 0, iss: issuer, sub: 'user-1' },
+    },
+    {
+      name: 'wrong issuer',
+      claims: {
+        aud: 'functional-api',
+        iss: 'https://attacker.example.test',
+        sub: 'user-1',
+      },
+    },
+    { name: 'missing audience', claims: { iss: issuer, sub: 'user-1' } },
+  ])('rejects strict access tokens with $name', async ({ claims, untrusted }) => {
+    const token = await (untrusted ? untrustedSigningFixture : signingFixture).sign(claims)
+    const harness = new HandlerHarness({ runtimeConfig: createStrictRuntimeConfig() })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: token, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+  })
+
+  it.each([
+    { name: 'string', audience: 'functional-api' },
+    { name: 'array', audience: ['another-audience', 'functional-api'] },
+  ])('accepts strict access tokens with matching $name audience', async ({ audience }) => {
+    const token = await signingFixture.sign({ aud: audience, iss: issuer, sub: 'user-1' })
+    const harness = new HandlerHarness({ runtimeConfig: createStrictRuntimeConfig() })
+    seedCallbackSession(harness)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json({ access_token: token, token_type: 'Bearer' }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+  })
+
   it('validates strict access tokens even when their decoded audience does not match', async () => {
     const wrongAudienceToken = await signingFixture.sign({
       aud: 'functional-client',

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -300,7 +300,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it.each([
@@ -344,7 +344,7 @@ describe('callback token validation', () => {
     await invokeCallback(harness)
 
     expect(interceptor.requests.map((request) => request.url)).toContain(jwksUri)
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('validates enabled ID tokens independently from disabled access-token validation', async () => {
@@ -549,7 +549,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it.each(['sub', 'iat'] as const)('requires %s in strict ID tokens', async (missingClaim) => {
@@ -584,7 +584,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('requires sub to be a string in strict ID tokens', async () => {
@@ -617,7 +617,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('preserves legacy multi-audience ID tokens without azp', async () => {
@@ -670,7 +670,7 @@ describe('callback token validation', () => {
     await invokeCallback(harness)
 
     expect(interceptor.requests).toHaveLength(1)
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('requires exp in strict mode', async () => {
@@ -697,7 +697,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it.each([
@@ -728,7 +728,7 @@ describe('callback token validation', () => {
     await invokeCallback(harness)
 
     expect(interceptor.requests).toHaveLength(1)
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('accepts strict discovery issuer arrays', async () => {
@@ -782,7 +782,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('preserves malformed legacy issuer arrays for fail-closed validation', async () => {
@@ -810,7 +810,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('rejects mixed-type legacy issuer arrays instead of dropping issuer validation', async () => {
@@ -840,7 +840,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('does not inspect malformed decoded audiences before strict validation', async () => {
@@ -868,7 +868,7 @@ describe('callback token validation', () => {
 
     await expect(invokeCallback(harness)).resolves.toBeDefined()
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('preserves legacy validation without exp and matches array audiences by exact member', async () => {
@@ -938,7 +938,7 @@ describe('callback token validation', () => {
 
     await invokeCallback(harness)
 
-    expect(harness.inspectSession('nuxt-oidc-auth')).toMatchObject({ data: {} })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
   })
 
   it('uses exact legacy string audience matching and warns once per provider', async () => {


### PR DESCRIPTION
## Summary

- add explicit strict JWT regressions for signature, expiration, issuer, and audience failures
- prove matching string and array audiences with in-test RS256 keys and JWKS
- make unsigned offline OIDC fixture validation opt-outs explicit
- document migration boundary, future strict-default prerequisite, and release note

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 51/51 passed
- focused callback/config coverage - 78/78 passed
- `pnpm test:e2e --workers=1` with Nix Chrome - 32 passed, 32 provider-config-gated skipped
- `pnpm prepack` - passed
- independent security review - no findings

## Environment note

`pnpm dev:prepare` generated root types, then stopped during playground preparation because its existing UnoCSS config points to missing `uno.config.ts`. Required lint, typecheck, tests, E2E, and prepack gates passed afterward.

Closes #165
Tracks #161