### PR TITLE
docs(auth0): explain opaque access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **auth:** Prevent client overrides of reserved OAuth/OIDC authorization parameters
 - **auth:** Preserve dynamic callback redirects and reject unsafe local redirect paths
 - **auth:** Add strict callback token validation and migration guidance
+- **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 
 ## v1.0.0-beta.11

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -77,6 +77,6 @@ Strict access-token validation requires `audience`. Any enabled strict validatio
 
 Refresh responses are not yet covered by `tokenValidationMode`; refreshed tokens retain existing parsing behavior until strict refresh validation is delivered.
 
-Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently.
+Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently. `tokenValidationMode: 'strict'` does not override these opt-outs and validates only token types enabled by their `validate*Token` flag.
 
 Offline end-to-end tests use the generic `oidc` fixture with access-token and ID-token validation explicitly disabled because its mock provider emits random-string signatures and a placeholder JWKS. Before strict validation becomes default, that fixture must issue tokens and JWKS signed with test key material and enable strict validation.

--- a/docs/content/2.provider/2.auth0.md
+++ b/docs/content/2.provider/2.auth0.md
@@ -39,11 +39,13 @@ auth0: {
   clientId: '',
   clientSecret: '',
   skipAccessTokenParsing: true,
+  tokenValidationMode: 'strict',
   validateAccessToken: false,
+  validateIdToken: true,
 },
 ```
 
-`tokenValidationMode: 'strict'` does not override these flags. You can enable `validateIdToken: true` independently to validate the ID token while preserving the opaque access token.
+Strict mode does not override the access-token opt-outs and validates the enabled ID token independently while preserving the opaque access token.
 
 ## Example Configuration
 

--- a/docs/content/2.provider/2.auth0.md
+++ b/docs/content/2.provider/2.auth0.md
@@ -10,7 +10,7 @@ icon: i-simple-icons-auth0
 ❌&nbsp; Nonce<br>
 ✅&nbsp; State<br>
 ✅&nbsp; Access Token validation<br>
-✅&nbsp; ID Token validation<br>
+⚠️&nbsp; ID Token validation (Supported, but disabled by default)<br>
 
 ## Introduction
 

--- a/docs/content/2.provider/2.auth0.md
+++ b/docs/content/2.provider/2.auth0.md
@@ -28,6 +28,23 @@ Additional parameters to be used in `additionalAuthParameters`, `additionalToken
 
 Depending on the settings of your apps `Credentials` tab, set `authenticationScheme` to `body` for 'Client Secret (Post)', set to `header` for 'Client Secret (Basic)', set to `''` for 'None'
 
+## Opaque access tokens without an audience
+
+When no API audience is requested or configured as the tenant's default, [Auth0 issues an opaque access token](https://dev.auth0.com/docs/secure/tokens/access-tokens/get-access-tokens) intended for its `/userinfo` endpoint. Opaque tokens cannot be decoded or validated locally as JWTs, so configure both access-token opt-outs:
+
+```typescript [nuxt.config.ts]
+auth0: {
+  redirectUri: 'http://localhost:3000/auth/auth0/callback',
+  baseUrl: '',
+  clientId: '',
+  clientSecret: '',
+  skipAccessTokenParsing: true,
+  validateAccessToken: false,
+},
+```
+
+`tokenValidationMode: 'strict'` does not override these flags. You can enable `validateIdToken: true` independently to validate the ID token while preserving the opaque access token.
+
 ## Example Configuration
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}

--- a/docs/content/2.provider/2.auth0.md
+++ b/docs/content/2.provider/2.auth0.md
@@ -10,7 +10,7 @@ icon: i-simple-icons-auth0
 ❌&nbsp; Nonce<br>
 ✅&nbsp; State<br>
 ✅&nbsp; Access Token validation<br>
-❌&nbsp; ID Token validation<br>
+✅&nbsp; ID Token validation<br>
 
 ## Introduction
 

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -377,6 +377,86 @@ describe('callback token validation', () => {
   })
 
   it.each([
+    { name: 'accepts a trusted ID token', trusted: true },
+    { name: 'rejects an untrusted ID token', trusted: false },
+  ])('$name with an Auth0 opaque access token', async ({ trusted }) => {
+    const auth0TokenUrl = `${issuer}/oauth/token`
+    const discoveryUrl = `${issuer}/.well-known/openid-configuration`
+    const opaqueAccessToken = 'opaque-auth0-access-token'
+    const idToken = await (trusted ? signingFixture : untrustedSigningFixture).sign({
+      aud: 'functional-client',
+      iss: issuer,
+      sub: 'user-1',
+    })
+    const harness = new HandlerHarness({
+      runtimeConfig: {
+        oidc: {
+          session: {
+            maxAge: 3600,
+            automaticRefresh: false,
+            expirationCheck: false,
+          },
+          providers: {
+            auth0: {
+              baseUrl: issuer,
+              clientId: 'functional-client',
+              clientSecret: 'functional-secret',
+              redirectUri: 'https://app.example.test/auth/auth0/callback',
+              tokenValidationMode: 'strict',
+              skipAccessTokenParsing: true,
+              validateAccessToken: false,
+              validateIdToken: true,
+            },
+          },
+        },
+      },
+    })
+    harness.cookieJar.seedSession('oidc', {
+      state: 'functional-state',
+      codeVerifier: 'functional-code-verifier',
+      redirect: 'https://app.example.test/auth/auth0/callback',
+    })
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: auth0TokenUrl,
+        respond: () =>
+          Response.json({
+            access_token: opaqueAccessToken,
+            id_token: idToken,
+            token_type: 'Bearer',
+          }),
+      },
+      {
+        url: discoveryUrl,
+        respond: () => Response.json({ issuer, jwks_uri: jwksUri }),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+      {
+        url: `${issuer}/userinfo`,
+        respond: () => Response.json({ sub: 'user-1' }),
+      },
+    ])
+    const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+    const request = harness.createEvent({
+      path: '/auth/auth0/callback',
+      query: { code: 'functional-code', state: 'functional-state' },
+    })
+
+    await callbackHandler(request.event)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      trusted ? expect.objectContaining({ provider: 'auth0', userInfo: { sub: 'user-1' } }) : {},
+    )
+    const userInfoRequest = interceptor.requests.find(
+      (fetchRequest) => fetchRequest.url === `${issuer}/userinfo`,
+    )
+    expect(userInfoRequest?.headers.get('authorization')).toBe(
+      trusted ? `Bearer ${opaqueAccessToken}` : undefined,
+    )
+  })
+
+  it.each([
     { name: 'missing', azp: undefined, accepted: false },
     { name: 'different', azp: 'another-client', accepted: false },
     { name: 'matching', azp: 'functional-client', accepted: true },


### PR DESCRIPTION
## Summary

- document Auth0 opaque access tokens when no API audience is requested or configured
- show required access-token parsing and validation opt-outs
- clarify that strict mode validates enabled token types independently
- exercise the Auth0 preset through callback, discovery, JWKS, and userinfo with trusted and untrusted ID tokens

## Root cause

Auth0 can return an opaque access token for `/userinfo` when no API audience is requested or configured as tenant default. Existing Auth0 guidance marked `audience` optional but did not explain that opaque tokens require `skipAccessTokenParsing: true` and `validateAccessToken: false`, so callback parsing failed before login completed.

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 53/53 passed
- focused callback coverage - 44/44 passed
- `pnpm prepack` - module build and static client generation passed
- independent security review - no findings

## Environment note

`pnpm dev:prepare` generated root types, then stopped during playground preparation because its existing UnoCSS config points to missing `uno.config.ts`. Required lint, typecheck, tests, and prepack gates passed afterward.

Closes #117
Tracks #161
Tracks #164