### PR TITLE
fix(auth): preserve token request values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **auth:** Prevent client overrides of reserved OAuth/OIDC authorization parameters
 - **auth:** Preserve dynamic callback redirects and reject unsafe local redirect paths
 - **auth:** Add strict callback token validation and migration guidance
+- **auth:** Preserve token request values during transport encoding
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -13,7 +13,7 @@ import type { JwtPayload } from '../utils/security'
 import { useRuntimeConfig } from '#imports'
 import { deleteCookie, eventHandler, getQuery, getRequestURL, readBody, sendRedirect } from 'h3'
 import { useStorage } from 'nitropack/runtime'
-import { normalizeURL, parseURL } from 'ufo'
+import { parseURL } from 'ufo'
 import * as providerPresets from '../../providers'
 import {
   hasExplicitProviderConfig,
@@ -24,6 +24,7 @@ import { textToBase64 } from '../utils/encoding'
 import {
   convertObjectToSnakeCase,
   convertTokenRequestToType,
+  formatTokenRequestError,
   oidcErrorHandler,
   useOidcLogger,
 } from '../utils/oidc'
@@ -183,7 +184,7 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       ...(config.pkce && { code_verifier: session.data.codeVerifier }),
       ...(config.authenticationScheme &&
         config.authenticationScheme === 'body' && {
-          client_secret: normalizeURL(config.clientSecret),
+          client_secret: config.clientSecret,
         }),
       ...(config.additionalTokenParameters &&
         convertObjectToSnakeCase(config.additionalTokenParameters)),
@@ -198,15 +199,10 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
         body: convertTokenRequestToType(requestBody, config.tokenRequestType ?? undefined),
       })
     } catch (error: unknown) {
-      // Log ofetch error data to console
       const fetchError = error as {
         data?: { error?: string; error_description?: string; suberror?: string }
       }
-      logger.error(
-        fetchError?.data
-          ? `${fetchError.data.error}: ${fetchError.data.error_description}`
-          : String(error),
-      )
+      logger.error(formatTokenRequestError(error, config.clientSecret))
 
       // Handle Microsoft consent_required error
       if (fetchError?.data?.suberror === 'consent_required') {

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -3,7 +3,6 @@ import type { H3Event } from 'h3'
 import type { OidcProviderConfig } from './provider'
 import { createConsola } from 'consola'
 import { sendRedirect } from 'h3'
-import { normalizeURL } from 'ufo'
 import { createProviderFetch } from './provider'
 import { textToBase64 } from './encoding'
 import { parseJwtToken } from './security'
@@ -40,7 +39,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
           : config.scope.join(' '),
       }),
     ...(config.authenticationScheme === 'body' && {
-      client_secret: normalizeURL(config.clientSecret),
+      client_secret: config.clientSecret,
     }),
   }
   // Make refresh token request
@@ -52,12 +51,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
       body: convertTokenRequestToType(requestBody, config.tokenRequestType),
     })
   } catch (error: unknown) {
-    const fetchError = error as { data?: { error?: string; error_description?: string } }
-    throw new Error(
-      fetchError?.data
-        ? `${fetchError.data.error}: ${fetchError.data.error_description}`
-        : String(error),
-    )
+    throw new Error(formatTokenRequestError(error, config.clientSecret))
   }
 
   // Construct tokens object
@@ -100,10 +94,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
 export function generateFormDataRequest(requestValues: RefreshTokenRequest | TokenRequest) {
   const requestBody = new FormData()
   Object.keys(requestValues).forEach((key) => {
-    requestBody.append(
-      key,
-      normalizeURL(requestValues[key as keyof typeof requestValues] as string),
-    )
+    requestBody.append(key, requestValues[key as keyof typeof requestValues] as string)
   })
   return requestBody
 }
@@ -111,7 +102,7 @@ export function generateFormDataRequest(requestValues: RefreshTokenRequest | Tok
 export function generateFormUrlEncodedRequest(requestValues: RefreshTokenRequest | TokenRequest) {
   const requestBody = new URLSearchParams()
   Object.entries(requestValues).forEach((key) => {
-    if (typeof key[1] === 'string') requestBody.append(key[0], normalizeURL(key[1]))
+    if (typeof key[1] === 'string') requestBody.append(key[0], key[1])
   })
   return requestBody
 }
@@ -137,6 +128,27 @@ export function convertObjectToSnakeCase<T>(object: Record<string, T>) {
       return acc
     },
     {} as Record<string, T>,
+  )
+}
+
+export function formatTokenRequestError(error: unknown, clientSecret: string): string {
+  const fetchError = error as { data?: { error?: string; error_description?: string } }
+  const message = fetchError.data
+    ? `${fetchError.data.error}: ${fetchError.data.error_description}`
+    : String(error)
+  if (!clientSecret) return message
+
+  const formEncodedSecret = new URLSearchParams({ value: clientSecret })
+    .toString()
+    .slice('value='.length)
+  const encodedSecrets = new Set([
+    clientSecret,
+    encodeURIComponent(clientSecret),
+    formEncodedSecret,
+  ])
+  return [...encodedSecrets].reduce(
+    (redacted, secret) => redacted.replaceAll(secret, '[REDACTED]'),
+    message,
   )
 }
 

--- a/test/functional/token-request.test.ts
+++ b/test/functional/token-request.test.ts
@@ -1,0 +1,341 @@
+import type { OidcProviderConfig } from '../../src/runtime/server/utils/provider'
+import type * as OidcUtils from '../../src/runtime/server/utils/oidc'
+import { Buffer } from 'node:buffer'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+type TokenRequestType = NonNullable<OidcProviderConfig['tokenRequestType']>
+
+const tokenUrl = 'https://identity.example.test/token'
+const specialClientId = 'client+/%=&-clïent'
+const specialClientSecret = 'secret +/%=&-sëcret'
+const specialValue = 'value+/%=&-välue'
+const redirectUri = `https://app.example.test/auth/oidc/callback?return=${encodeURIComponent(specialValue)}`
+const encodedClientSecrets = [
+  specialClientSecret,
+  encodeURIComponent(specialClientSecret),
+  new URLSearchParams({ value: specialClientSecret }).toString().slice('value='.length),
+]
+expect(new Set(encodedClientSecrets)).toHaveLength(3)
+let accessToken: string
+
+const testLogger = vi.hoisted(() => ({
+  error: vi.fn<(...args: unknown[]) => void>(),
+  info: vi.fn<(...args: unknown[]) => void>(),
+  warn: vi.fn<(...args: unknown[]) => void>(),
+}))
+
+vi.mock('../../src/runtime/server/utils/oidc', async (importOriginal) => {
+  const actual = await importOriginal<typeof OidcUtils>()
+  return { ...actual, useOidcLogger: () => testLogger }
+})
+
+beforeAll(async () => {
+  const signingFixture = await createRs256Fixture()
+  accessToken = await signingFixture.sign({ sub: 'user-1' })
+})
+
+beforeEach(() => {
+  testLogger.error.mockClear()
+  testLogger.info.mockClear()
+  testLogger.warn.mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function readTokenRequest(
+  request: Request,
+  requestType: TokenRequestType,
+): Promise<Record<string, string>> {
+  if (requestType === 'json') {
+    const body: unknown = await request.json()
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw new Error('Expected a JSON object token request')
+    }
+    return Object.fromEntries(Object.entries(body).map(([key, value]) => [key, String(value)]))
+  }
+
+  if (requestType === 'form-urlencoded') {
+    return Object.fromEntries(new URLSearchParams(await request.text()))
+  }
+
+  const body = await request.formData()
+  return Object.fromEntries(
+    [...body.entries()].map(([key, value]) => [
+      key,
+      typeof value === 'string' ? value : value.name,
+    ]),
+  )
+}
+
+function expectContentType(request: Request, requestType: TokenRequestType): void {
+  const contentType = request.headers.get('content-type')
+  if (requestType === 'json') {
+    expect(contentType).toContain('application/json')
+  } else if (requestType === 'form-urlencoded') {
+    expect(contentType).toContain('application/x-www-form-urlencoded')
+  } else {
+    expect(contentType).toContain('multipart/form-data')
+  }
+}
+
+function expectClientSecretRedacted(message: string): void {
+  expect(message).toContain('[REDACTED]')
+  for (const clientSecret of encodedClientSecrets) {
+    expect(message).not.toContain(clientSecret)
+  }
+}
+
+function createCallbackRuntimeConfig(
+  tokenRequestType: TokenRequestType,
+  authenticationScheme: OidcProviderConfig['authenticationScheme'] = 'body',
+) {
+  return {
+    oidc: {
+      session: {
+        maxAge: 3600,
+        automaticRefresh: false,
+        expirationCheck: false,
+      },
+      providers: {
+        oidc: {
+          authenticationScheme,
+          clientId: specialClientId,
+          clientSecret: specialClientSecret,
+          authorizationUrl: 'https://identity.example.test/authorize',
+          tokenUrl,
+          redirectUri,
+          scope: ['openid', specialValue],
+          scopeInTokenRequest: true,
+          tokenRequestType,
+          userInfoUrl: '',
+          validateAccessToken: false,
+          validateIdToken: false,
+          additionalTokenParameters: { customParameter: specialValue },
+          requiredProperties: [
+            'clientId',
+            'clientSecret',
+            'authorizationUrl',
+            'tokenUrl',
+            'redirectUri',
+          ],
+        },
+      },
+    },
+  }
+}
+
+function createRefreshConfig(
+  tokenRequestType: TokenRequestType,
+  authenticationScheme: OidcProviderConfig['authenticationScheme'] = 'body',
+): OidcProviderConfig {
+  return {
+    authenticationScheme,
+    authorizationUrl: 'https://identity.example.test/authorize',
+    clientId: specialClientId,
+    clientSecret: specialClientSecret,
+    grantType: 'authorization_code',
+    redirectUri,
+    requiredProperties: ['clientId', 'clientSecret', 'tokenUrl'],
+    responseMode: 'query',
+    responseType: 'code',
+    scope: ['openid', specialValue, 'offline_access'],
+    scopeInTokenRequest: true,
+    excludeOfflineScopeFromTokenRequest: true,
+    tokenRequestType,
+    tokenUrl,
+  }
+}
+
+describe('token request transport encoding', () => {
+  it.each<TokenRequestType>(['form', 'form-urlencoded', 'json'])(
+    'preserves callback values for %s requests',
+    async (tokenRequestType) => {
+      const harness = new HandlerHarness({
+        runtimeConfig: createCallbackRuntimeConfig(tokenRequestType),
+      })
+      harness.cookieJar.seedSession('oidc', {
+        state: 'functional-state',
+        codeVerifier: specialValue,
+        redirect: redirectUri,
+      })
+      const interceptor = interceptFetch([
+        {
+          method: 'POST',
+          url: tokenUrl,
+          respond: () =>
+            Response.json({ access_token: accessToken, token_type: 'Bearer', expires_in: '300' }),
+        },
+      ])
+      const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+      const event = harness.createEvent({
+        path: '/auth/oidc/callback',
+        query: { code: specialValue, state: 'functional-state' },
+      })
+
+      await callbackHandler(event.event)
+
+      expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({ provider: 'oidc' })
+      expect(interceptor.requests).toHaveLength(1)
+      const request = interceptor.requests[0]!
+      expectContentType(request, tokenRequestType)
+      await expect(readTokenRequest(request, tokenRequestType)).resolves.toMatchObject({
+        client_id: specialClientId,
+        client_secret: specialClientSecret,
+        code: specialValue,
+        code_verifier: specialValue,
+        custom_parameter: specialValue,
+        grant_type: 'authorization_code',
+        redirect_uri: redirectUri,
+        scope: `openid ${specialValue}`,
+      })
+    },
+  )
+
+  it('base64-encodes original callback credentials for header authentication', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig: createCallbackRuntimeConfig('form-urlencoded', 'header'),
+    })
+    harness.cookieJar.seedSession('oidc', {
+      state: 'functional-state',
+      codeVerifier: specialValue,
+      redirect: redirectUri,
+    })
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, token_type: 'Bearer', expires_in: '300' }),
+      },
+    ])
+    const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+    const event = harness.createEvent({
+      path: '/auth/oidc/callback',
+      query: { code: specialValue, state: 'functional-state' },
+    })
+
+    await callbackHandler(event.event)
+
+    const request = interceptor.requests[0]!
+    const authorization = request.headers.get('authorization')
+    expect(authorization).toMatch(/^Basic /)
+    expect(Buffer.from(authorization!.slice('Basic '.length), 'base64').toString('utf8')).toBe(
+      `${specialClientId}:${specialClientSecret}`,
+    )
+    expect((await readTokenRequest(request, 'form-urlencoded')).client_secret).toBeUndefined()
+  })
+
+  it('redacts reflected client secrets from callback errors', async () => {
+    const harness = new HandlerHarness({
+      runtimeConfig: createCallbackRuntimeConfig('form-urlencoded'),
+    })
+    harness.cookieJar.seedSession('oidc', {
+      state: 'functional-state',
+      codeVerifier: specialValue,
+      redirect: redirectUri,
+    })
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json(
+            {
+              error: 'invalid_client',
+              error_description: encodedClientSecrets.join(' | '),
+            },
+            { status: 401 },
+          ),
+      },
+    ])
+    const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+    const event = harness.createEvent({
+      path: '/auth/oidc/callback',
+      query: { code: specialValue, state: 'functional-state' },
+    })
+
+    await callbackHandler(event.event)
+
+    expectClientSecretRedacted(testLogger.error.mock.calls.flat().map(String).join(' '))
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+  })
+
+  it.each<TokenRequestType>(['form', 'form-urlencoded', 'json'])(
+    'preserves refresh values for %s requests',
+    async (tokenRequestType) => {
+      const { refreshAccessToken } = await import('../../src/runtime/server/utils/oidc')
+      const interceptor = interceptFetch([
+        {
+          method: 'POST',
+          url: tokenUrl,
+          respond: () =>
+            Response.json({ access_token: accessToken, token_type: 'Bearer', expires_in: '300' }),
+        },
+      ])
+
+      await refreshAccessToken(specialValue, createRefreshConfig(tokenRequestType))
+
+      expect(interceptor.requests).toHaveLength(1)
+      const request = interceptor.requests[0]!
+      expectContentType(request, tokenRequestType)
+      await expect(readTokenRequest(request, tokenRequestType)).resolves.toMatchObject({
+        client_id: specialClientId,
+        client_secret: specialClientSecret,
+        grant_type: 'refresh_token',
+        refresh_token: specialValue,
+        scope: `openid ${specialValue}`,
+      })
+    },
+  )
+
+  it('base64-encodes original refresh credentials for header authentication', async () => {
+    const { refreshAccessToken } = await import('../../src/runtime/server/utils/oidc')
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({ access_token: accessToken, token_type: 'Bearer', expires_in: '300' }),
+      },
+    ])
+
+    await refreshAccessToken(specialValue, createRefreshConfig('form-urlencoded', 'header'))
+
+    const request = interceptor.requests[0]!
+    const authorization = request.headers.get('authorization')
+    expect(authorization).toMatch(/^Basic /)
+    expect(Buffer.from(authorization!.slice('Basic '.length), 'base64').toString('utf8')).toBe(
+      `${specialClientId}:${specialClientSecret}`,
+    )
+    expect((await readTokenRequest(request, 'form-urlencoded')).client_secret).toBeUndefined()
+  })
+
+  it('redacts reflected client secrets from refresh errors', async () => {
+    const { refreshAccessToken } = await import('../../src/runtime/server/utils/oidc')
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json(
+            {
+              error: 'invalid_client',
+              error_description: encodedClientSecrets.join(' | '),
+            },
+            { status: 401 },
+          ),
+      },
+    ])
+
+    const requestError: unknown = await refreshAccessToken(
+      specialValue,
+      createRefreshConfig('form-urlencoded'),
+    ).catch((error: unknown) => error)
+
+    expect(requestError).toBeInstanceOf(Error)
+    expectClientSecretRedacted(String(requestError))
+  })
+})


### PR DESCRIPTION
## Summary
- preserve raw callback and refresh values until native request-body encoding
- keep original credentials for body and Basic authentication
- cover multipart form, URL-encoded form, and JSON token requests
- redact reflected client secrets from token endpoint errors

## Root cause
Token request fields passed through URL normalization before FormData or URLSearchParams encoded them. Reserved characters and non-ASCII values could be changed before transport encoding, producing invalid credentials or request parameters.

## Validation
- `pnpm fmt:check`
- `pnpm lint` (0 errors; 24 existing warnings)
- `pnpm typecheck`
- `pnpm test:unit` (141 passed)
- `pnpm test:functional` (63 passed)
- focused token-request tests (10 passed)
- serial E2E with Nix Chrome (32 passed; 32 provider-configured skips)
- `pnpm prepack`
- independent security review

## Environment note
`pnpm dev:prepare` generated root types, then stopped in playground preparation because existing UnoCSS setup cannot find `uno.config.ts`. Module and client production builds pass through `pnpm prepack`.

Closes #123
Tracks #179
Tracks #191