### PR TITLE
fix(session): replace token-derived data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **auth:** Preserve dynamic callback redirects and reject unsafe local redirect paths
 - **auth:** Add strict callback token validation and migration guidance
 - **auth:** Preserve token request values during transport encoding
+- **session:** Replace token-derived data on login and refresh
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -31,7 +31,7 @@ import {
 import { createProviderFetch } from '../utils/provider'
 import { resolveCallbackRedirectUrl } from '../utils/redirect'
 import { encryptToken, parseJwtToken, validateToken } from '../utils/security'
-import { getUserSessionId, setUserSession, useAuthSession } from '../utils/session'
+import { getUserSessionId, replaceTokenDerivedUserSession, useAuthSession } from '../utils/session'
 
 const warnedLegacyValidationProviders = new Set<ProviderKeys>()
 
@@ -415,7 +415,7 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
 
 export default callbackEventHandler({
   async onSuccess(event, { user, callbackRedirectUrl }) {
-    await setUserSession(event, user as UserSession)
+    await replaceTokenDerivedUserSession(event, user as UserSession)
     return sendRedirect(event, callbackRedirectUrl || ('/' as string))
   },
 })

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -21,7 +21,9 @@ import { resolveMissingPersistentSessionMode } from './session-options'
 
 const DEFAULT_SESSION_NAME = 'nuxt-oidc-auth'
 const TOKEN_DERIVED_USER_SESSION_FIELDS = [
+  'accessToken',
   'claims',
+  'idToken',
   'userInfo',
   'userName',
   'expireAt',
@@ -31,7 +33,9 @@ const TOKEN_DERIVED_USER_SESSION_FIELDS = [
   'updatedAt',
 ] as const satisfies readonly (keyof UserSession)[]
 const REFRESHED_USER_SESSION_FIELDS = [
+  'accessToken',
   'claims',
+  'idToken',
   'expireAt',
   'canRefresh',
   'updatedAt',

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -20,6 +20,22 @@ import { decryptToken, encryptToken } from './security'
 import { resolveMissingPersistentSessionMode } from './session-options'
 
 const DEFAULT_SESSION_NAME = 'nuxt-oidc-auth'
+const TOKEN_DERIVED_USER_SESSION_FIELDS = [
+  'claims',
+  'userInfo',
+  'userName',
+  'expireAt',
+  'canRefresh',
+  'provider',
+  'loggedInAt',
+  'updatedAt',
+] as const satisfies readonly (keyof UserSession)[]
+const REFRESHED_USER_SESSION_FIELDS = [
+  'claims',
+  'expireAt',
+  'canRefresh',
+  'updatedAt',
+] as const satisfies readonly (keyof UserSession)[]
 let sessionConfig: Pick<SessionConfig, 'name' | 'password'> & AuthSessionConfig
 const providerSessionConfigs = {} as Record<ProviderKeys, ProviderSessionConfig>
 
@@ -69,6 +85,15 @@ export async function setUserSession(event: H3Event, data: UserSession) {
   const session = await _useSession(event)
 
   await session.update(defu(data, session.data))
+
+  return session.data
+}
+
+export async function replaceTokenDerivedUserSession(event: H3Event, data: UserSession) {
+  const session = await _useSession(event)
+
+  clearUserSessionFields(session.data, TOKEN_DERIVED_USER_SESSION_FIELDS)
+  await session.update(data)
 
   return session.data
 }
@@ -190,7 +215,8 @@ export async function refreshUserSession(event: H3Event, options: SessionBehavio
     rawSession.createdAt = Date.now()
   }
 
-  await session.update(defu(userWithoutToken as UserSession, session.data))
+  clearUserSessionFields(session.data, REFRESHED_USER_SESSION_FIELDS)
+  await session.update(userWithoutToken as UserSession)
 
   return {
     ...session.data,
@@ -315,6 +341,11 @@ export async function getSingleSignOutSessionId(event: H3Event) {
 function resolveSessionName(config: AuthSessionConfig | undefined): string {
   const customName = config?.cookieName
   return customName && customName.length > 0 ? customName : DEFAULT_SESSION_NAME
+}
+
+function clearUserSessionFields(data: UserSession, fields: readonly (keyof UserSession)[]): void {
+  const partialData = data as Partial<UserSession>
+  for (const field of fields) delete partialData[field]
 }
 
 function _useSession(event: H3Event) {

--- a/test/functional/session-replacement.test.ts
+++ b/test/functional/session-replacement.test.ts
@@ -28,6 +28,7 @@ beforeAll(async () => {
 beforeEach(() => {
   mocks.decryptToken.mockResolvedValue('refresh-token')
   mocks.encryptToken.mockResolvedValue({ encryptedToken: 'encrypted', iv: 'iv' })
+  vi.stubEnv('NUXT_OIDC_AUTH_SESSION_SECRET', 'test-auth-session-secret-at-least-32-characters')
   vi.stubEnv('NUXT_OIDC_SESSION_SECRET', 'test-session-secret-at-least-32-characters')
   vi.stubEnv('NUXT_OIDC_TOKEN_KEY', 'test-token-key')
 })
@@ -125,6 +126,8 @@ describe('token-derived session replacement', () => {
       provider: 'oidc',
       canRefresh: false,
       expireAt: 1,
+      accessToken: 'previous-access-token',
+      idToken: 'previous-id-token',
       applicationData: { theme: 'dark' },
     })
     interceptFetch([
@@ -170,6 +173,8 @@ describe('token-derived session replacement', () => {
       }),
     )
     expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('userInfo')
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('accessToken')
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('idToken')
   })
 
   it('replaces refreshed nested claims on every cycle and keeps hook output current', async () => {
@@ -200,6 +205,8 @@ describe('token-derived session replacement', () => {
         provider: 'oidc',
         canRefresh: true,
         expireAt: 1,
+        accessToken: 'previous-access-token',
+        idToken: 'previous-id-token',
         loggedInAt: 1,
         updatedAt: 1,
         applicationData: { theme: 'dark' },
@@ -245,6 +252,8 @@ describe('token-derived session replacement', () => {
         expect(harness.inspectSession('nuxt-oidc-auth')?.data.claims).toEqual({
           resource_access: { playground: { roles: ['user-role'] } },
         })
+        expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('accessToken')
+        expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('idToken')
       }
     } finally {
       removeHook()

--- a/test/functional/session-replacement.test.ts
+++ b/test/functional/session-replacement.test.ts
@@ -1,0 +1,282 @@
+import type { UserSession } from '../../src/runtime/types'
+import type * as SecurityUtils from '../../src/runtime/server/utils/security'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+const tokenUrl = 'https://identity.example.test/token'
+const userInfoUrl = 'https://identity.example.test/userinfo'
+let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+
+const mocks = vi.hoisted(() => ({
+  decryptToken: vi.fn<() => Promise<string>>(),
+  encryptToken: vi.fn<() => Promise<{ encryptedToken: string; iv: string }>>(),
+}))
+
+vi.mock('../../src/runtime/server/utils/security', async (importOriginal) => {
+  const actual = await importOriginal<typeof SecurityUtils>()
+  return {
+    ...actual,
+    decryptToken: mocks.decryptToken,
+    encryptToken: mocks.encryptToken,
+  }
+})
+
+beforeAll(async () => {
+  signingFixture = await createRs256Fixture()
+})
+
+beforeEach(() => {
+  mocks.decryptToken.mockResolvedValue('refresh-token')
+  mocks.encryptToken.mockResolvedValue({ encryptedToken: 'encrypted', iv: 'iv' })
+  vi.stubEnv('NUXT_OIDC_SESSION_SECRET', 'test-session-secret-at-least-32-characters')
+  vi.stubEnv('NUXT_OIDC_TOKEN_KEY', 'test-token-key')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+function createRuntimeConfig() {
+  return {
+    oidc: {
+      session: {
+        maxAge: 3600,
+        automaticRefresh: false,
+        expirationCheck: false,
+      },
+      providers: {
+        oidc: {
+          clientId: 'functional-client',
+          clientSecret: 'functional-secret',
+          authorizationUrl: 'https://identity.example.test/authorize',
+          tokenUrl,
+          redirectUri: 'https://app.example.test/auth/oidc/callback',
+          userInfoUrl,
+          userNameClaim: 'preferred_username',
+          optionalClaims: ['resource_access', 'department'],
+          validateAccessToken: false,
+          validateIdToken: false,
+          requiredProperties: [
+            'clientId',
+            'clientSecret',
+            'authorizationUrl',
+            'tokenUrl',
+            'redirectUri',
+          ],
+        },
+      },
+    },
+  }
+}
+
+function seedAuthSession(harness: HandlerHarness): void {
+  harness.cookieJar.seedSession('oidc', {
+    state: 'functional-state',
+    codeVerifier: 'functional-code-verifier',
+    redirect: 'https://app.example.test/auth/oidc/callback',
+  })
+}
+
+async function invokeCallback(harness: HandlerHarness): Promise<void> {
+  const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+  const request = harness.createEvent({
+    path: '/auth/oidc/callback',
+    query: { code: 'functional-code', state: 'functional-state' },
+  })
+  await callbackHandler(request.event)
+  request.commitResponseCookies()
+}
+
+describe('token-derived session replacement', () => {
+  it('replaces previous identity data while preserving application session fields', async () => {
+    const firstAccessToken = await signingFixture.sign({
+      preferred_username: 'pgadmin',
+      sub: 'admin-user',
+    })
+    const firstIdToken = await signingFixture.sign({
+      department: 'administration',
+      resource_access: { playground: { roles: ['admin-role'] } },
+      sub: 'admin-user',
+    })
+    const secondAccessToken = await signingFixture.sign({ sub: 'regular-user' })
+    const secondIdToken = await signingFixture.sign({
+      resource_access: { playground: { roles: ['user-role'] } },
+      sub: 'regular-user',
+    })
+    const tokenResponses = [
+      {
+        access_token: firstAccessToken,
+        id_token: firstIdToken,
+        token_type: 'Bearer',
+        expires_in: '300',
+      },
+      {
+        access_token: secondAccessToken,
+        id_token: secondIdToken,
+        token_type: 'Bearer',
+        expires_in: '300',
+      },
+    ]
+    let tokenResponseIndex = 0
+    let userInfoRequestCount = 0
+    const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig() })
+    harness.cookieJar.seedSession('nuxt-oidc-auth', {
+      provider: 'oidc',
+      canRefresh: false,
+      expireAt: 1,
+      applicationData: { theme: 'dark' },
+    })
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json(tokenResponses[tokenResponseIndex++]!),
+      },
+      {
+        url: userInfoUrl,
+        respond: () => {
+          userInfoRequestCount += 1
+          return userInfoRequestCount === 1
+            ? Response.json({ displayName: 'Playground Admin' })
+            : Response.json({ error: 'not_found' }, { status: 404 })
+        },
+      },
+    ])
+
+    seedAuthSession(harness)
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toMatchObject({
+      userName: 'pgadmin',
+      userInfo: { displayName: 'Playground Admin' },
+      claims: {
+        department: 'administration',
+        resource_access: { playground: { roles: ['admin-role'] } },
+      },
+    })
+
+    seedAuthSession(harness)
+    await invokeCallback(harness)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      expect.objectContaining({
+        provider: 'oidc',
+        userName: '',
+        applicationData: { theme: 'dark' },
+        claims: {
+          resource_access: { playground: { roles: ['user-role'] } },
+        },
+      }),
+    )
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toHaveProperty('userInfo')
+  })
+
+  it('replaces refreshed nested claims on every cycle and keeps hook output current', async () => {
+    const refreshedAccessToken = await signingFixture.sign({ sub: 'regular-user' })
+    const refreshedIdToken = await signingFixture.sign({
+      resource_access: { playground: { roles: ['user-role'] } },
+      sub: 'regular-user',
+    })
+    const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig() })
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({
+            access_token: refreshedAccessToken,
+            id_token: refreshedIdToken,
+            refresh_token: 'new-refresh-token',
+            token_type: 'Bearer',
+            expires_in: '3600',
+          }),
+      },
+    ])
+    const sessionId = 'refresh-session'
+    harness.cookieJar.seedSession(
+      'nuxt-oidc-auth',
+      {
+        provider: 'oidc',
+        canRefresh: true,
+        expireAt: 1,
+        loggedInAt: 1,
+        updatedAt: 1,
+        applicationData: { theme: 'dark' },
+        claims: {
+          department: 'administration',
+          resource_access: { playground: { roles: ['admin-role'] } },
+        },
+      },
+      sessionId,
+    )
+    await harness.storage('oidc').setItem(sessionId, {
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      exp: 1,
+      iat: 1,
+      accessToken: { encryptedToken: 'encrypted', iv: 'iv' },
+      refreshToken: { encryptedToken: 'encrypted', iv: 'iv' },
+    })
+    const { refreshUserSession, sessionHooks } =
+      await import('../../src/runtime/server/utils/session')
+    const removeHook = sessionHooks.hook('refresh', (session) => {
+      session.claims = { ...session.claims, status: 'Refresh' }
+    })
+
+    try {
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        const request = harness.createEvent({ path: '/api/_auth/session/refresh' })
+        const session = await refreshUserSession(request.event)
+        await sessionHooks.callHookParallel('refresh', session, request.event)
+        request.commitResponseCookies()
+
+        expect(session).toEqual(
+          expect.objectContaining({
+            provider: 'oidc',
+            loggedInAt: 1,
+            applicationData: { theme: 'dark' },
+            claims: {
+              resource_access: { playground: { roles: ['user-role'] } },
+              status: 'Refresh',
+            },
+          }),
+        )
+        expect(harness.inspectSession('nuxt-oidc-auth')?.data.claims).toEqual({
+          resource_access: { playground: { roles: ['user-role'] } },
+        })
+      }
+    } finally {
+      removeHook()
+    }
+
+    expect(interceptor.requests).toHaveLength(2)
+  })
+
+  it('keeps setUserSession merge behavior for external callers', async () => {
+    const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig() })
+    harness.cookieJar.seedSession('nuxt-oidc-auth', {
+      provider: 'oidc',
+      canRefresh: false,
+      expireAt: 1,
+      claims: { existing: 'preserved' },
+      applicationData: { theme: 'dark' },
+    })
+    const event = harness.createEvent({ path: '/api/custom-session' })
+    const { setUserSession } = await import('../../src/runtime/server/utils/session')
+
+    await setUserSession(event.event, {
+      provider: 'oidc',
+      canRefresh: true,
+      expireAt: 2,
+      claims: { added: 'value' },
+    } satisfies UserSession)
+
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      expect.objectContaining({
+        applicationData: { theme: 'dark' },
+        claims: { added: 'value', existing: 'preserved' },
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- replace token-derived session data after callback instead of deep-merging it with a previous identity
- replace refreshed claims and timestamps without merging nested arrays
- preserve application-defined session fields and current refresh-hook output
- keep public `setUserSession` signature and merge behavior unchanged

## Root cause
Callback and refresh flows passed new token-derived data through `defu` with existing session data. Nested objects and arrays were merged, so old claims could survive a later login and repeated refreshes could grow claim arrays.

## Validation
- `pnpm fmt:check`
- `pnpm lint` (0 errors; 24 existing warnings)
- `pnpm typecheck`
- `pnpm test:unit` (141 passed)
- `pnpm test:functional` (66 passed)
- focused session replacement tests (3 passed)
- serial E2E with Nix Chrome (32 passed; 32 provider-configured skips)
- `pnpm prepack`
- independent xhigh security review

## Environment note
`pnpm dev:prepare` generated root types, then stopped in playground preparation because existing UnoCSS setup cannot find `uno.config.ts`. Module and client production builds pass through `pnpm prepack`.

Closes #127
Tracks #179
Tracks #191