### PR TITLE
fix(auth): validate refreshed tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **auth:** Add strict callback token validation and migration guidance
 - **auth:** Preserve token request values during transport encoding
 - **session:** Replace token-derived data on login and refresh
+- **auth:** Validate strict-mode refresh token responses
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -67,7 +67,7 @@ ID and access token validation involves verifying the integrity and claims of th
 We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in callback and refresh token responses without trusting its decoded claims first. Strict validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
-- ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled.
+- ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled. Refreshed ID tokens must retain the original ID-token subject.
 
 Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -67,7 +67,7 @@ ID and access token validation involves verifying the integrity and claims of th
 We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in callback and refresh token responses without trusting its decoded claims first. Strict validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
-- ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled. Refreshed ID tokens must retain the original ID-token subject.
+- ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled. Refreshed ID tokens must retain the original ID-token subject and, when present, authentication time.
 
 Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 

--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -64,18 +64,18 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in the initial callback token response without trusting its decoded claims first. Strict callback validation verifies signature, expiration, issuer, and token-specific audience:
+We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in callback and refresh token responses without trusting its decoded claims first. Strict validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
-- ID tokens use configured `clientId` and require `sub`, `iat`, and a matching request nonce when nonce is enabled. Present `azp` must match `clientId`, and multi-audience ID tokens require it.
+- ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled.
 
 Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-`legacy` remains default for current production line. It validates enabled tokens only when decoded `aud` exactly equals configured audience or client ID, and emits one migration warning per provider when validation is skipped. Migrate providers issuing JWTs to `strict` after configuring required audience and discovery metadata. `strict` is intended to become default in next explicitly breaking release.
+`legacy` remains default for current production line. During callbacks, it validates enabled tokens only when decoded `aud` exactly equals configured audience or client ID, and emits one migration warning per provider when validation is skipped. Refresh responses retain existing parsing behavior. Migrate providers issuing JWTs to `strict` after configuring required audience and discovery metadata. `strict` is intended to become default in next explicitly breaking release.
 ::
 
-Refresh responses are not yet covered by `tokenValidationMode`; refreshed tokens retain existing parsing behavior until strict refresh validation is delivered.
+Strict refresh validation runs before session or persistent token state is updated. Invalid responses use existing refresh failure handling to clear stale session state.
 
 Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently. `tokenValidationMode: 'strict'` does not override these opt-outs and validates only token types enabled by their `validate*Token` flag.
 

--- a/docs/content/2.provider/1.index.md
+++ b/docs/content/2.provider/1.index.md
@@ -29,7 +29,7 @@ Nuxt OIDC Auth includes presets for the following providers with tested default 
 Some providers have specific additional fields that can be used to extend the authorization, logout or token request. These fields are available via. `additionalAuthParameters`, `additionalLogoutParameters` or `additionalTokenParameters` in the provider configuration.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-In legacy mode, enabled callback token validation runs only when decoded token audiences match `clientId` or configured `audience`. Strict mode validates every enabled JWT in the initial callback token response with token-specific audience rules. Providers issuing opaque access tokens require explicit validation and parsing opt-outs. See [security guidance](/getting-started/security#token-validation) for migration details.
+In legacy mode, enabled callback token validation runs only when decoded token audiences match `clientId` or configured `audience`, while refresh responses retain existing parsing behavior. Strict mode validates every enabled JWT in callback and refresh token responses with token-specific audience rules. Providers issuing opaque access tokens require explicit validation and parsing opt-outs. See [security guidance](/getting-started/security#token-validation) for migration details.
 ::
 
 The `redirectUri` property is always required and should always point to the callback uri of the specific provider. For Auth0 it should look like this `https://YOURDOMAIN/auth/auth0/callback`. The playgrounds nuxt.config.ts has examples for multiple providers.

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -76,7 +76,7 @@ export default defineNuxtConfig({
 | openIdConfiguration | `Record<string, unknown>` or `function (config) => Promise<Record<string, unknown>>` (optional) | `undefined` | OpenID Configuration object or function that resolves to an OpenID Configuration object. |
 | validateAccessToken | `boolean` (optional) | `true` | Validate access token. |
 | validateIdToken | `boolean` (optional) | `true` | Validate id token. |
-| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT in the initial callback token response with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. Refresh responses retain existing parsing behavior until strict refresh validation is delivered. |
+| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT in callback and refresh token responses with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. |
 | encodeRedirectUri | `boolean` (optional) | `false` | Encode redirect uri query parameter in authorization request. Only for compatibility with services that don't implement proper parsing of query parameters. |
 | exposeAccessToken | `boolean` (optional) | `false` | Expose access token to the client within session object |
 | exposeIdToken | `boolean` (optional) | `false` | Expose raw id token to the client within session object |

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -30,64 +30,11 @@ import {
 } from '../utils/oidc'
 import { createProviderFetch } from '../utils/provider'
 import { resolveCallbackRedirectUrl } from '../utils/redirect'
-import { encryptToken, parseJwtToken, validateToken } from '../utils/security'
+import { encryptToken, parseJwtToken } from '../utils/security'
 import { getUserSessionId, replaceTokenDerivedUserSession, useAuthSession } from '../utils/session'
+import { validateTokenResponse } from '../utils/token-validation'
 
 const warnedLegacyValidationProviders = new Set<ProviderKeys>()
-
-function hasExactAudience(payload: JwtPayload | undefined, expectedAudiences: string[]): boolean {
-  if (typeof payload?.aud === 'string') return expectedAudiences.includes(payload.aud)
-  if (!Array.isArray(payload?.aud)) return false
-  return payload.aud.some(
-    (audience) => typeof audience === 'string' && expectedAudiences.includes(audience),
-  )
-}
-
-function isIssuer(value: unknown): value is string | string[] {
-  return (
-    typeof value === 'string' ||
-    (Array.isArray(value) && value.every((issuer) => typeof issuer === 'string'))
-  )
-}
-
-function isStrictIssuer(value: unknown): value is string | string[] {
-  return (
-    (typeof value === 'string' && value.trim().length > 0) ||
-    (Array.isArray(value) &&
-      value.length > 0 &&
-      value.every((issuer) => typeof issuer === 'string' && issuer.trim().length > 0))
-  )
-}
-
-async function validateOidcIdToken(
-  token: string,
-  options: Parameters<typeof validateToken>[1],
-  clientId: string,
-  expectedNonce?: string,
-  nonceRequired = false,
-): Promise<JwtPayload> {
-  const payload = await validateToken(token, {
-    ...options,
-    requiredClaims: [...new Set([...(options.requiredClaims || []), 'sub', 'iat'])],
-  })
-  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
-    throw new Error('ID token sub must be a non-empty string')
-  }
-  const authorizedParty = payload.azp
-  if (
-    (Array.isArray(payload.aud) && payload.aud.length > 1 && typeof authorizedParty !== 'string') ||
-    (authorizedParty !== undefined && authorizedParty !== clientId)
-  ) {
-    throw new Error('ID token azp must match clientId and is required for multiple audiences')
-  }
-  if (nonceRequired && (typeof expectedNonce !== 'string' || expectedNonce.length === 0)) {
-    throw new Error('Authentication session is missing the expected nonce')
-  }
-  if (nonceRequired && payload.nonce !== expectedNonce) {
-    throw new Error('ID token nonce must match the authentication request')
-  }
-  return payload
-}
 
 function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   const logger = useOidcLogger()
@@ -226,96 +173,26 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       return oidcErrorHandler(event, `[${provider}] Token parsing failed: ${String(error)}`)
     }
 
-    const strictValidation = config.tokenValidationMode === 'strict'
-    if (strictValidation && config.validateIdToken && !tokenResponse.id_token) {
-      return oidcErrorHandler(event, `[${provider}] Token validation failed: Missing ID token`)
-    }
-
-    const legacyAudiences = [config.audience, config.clientId].filter(
-      (audience): audience is string => !!audience,
-    )
-    const legacyAudienceMatched =
-      !strictValidation &&
-      (hasExactAudience(accessToken, legacyAudiences) || hasExactAudience(idToken, legacyAudiences))
-    const validateAccessToken =
-      !!config.validateAccessToken && (strictValidation || legacyAudienceMatched)
-    const validateIdToken =
-      !!config.validateIdToken &&
-      !!tokenResponse.id_token &&
-      (strictValidation || legacyAudienceMatched)
-
-    if (validateAccessToken || validateIdToken) {
-      try {
-        const openIdConfiguration =
-          config.openIdConfiguration && typeof config.openIdConfiguration === 'object'
-            ? config.openIdConfiguration
-            : typeof config.openIdConfiguration === 'string'
-              ? await customFetch(config.openIdConfiguration)
-              : await config.openIdConfiguration!(config)
-        const issuer = openIdConfiguration.issuer
-        const jwksUri = openIdConfiguration.jwks_uri
-        if (
-          strictValidation &&
-          (!isStrictIssuer(issuer) || typeof jwksUri !== 'string' || !jwksUri)
-        ) {
-          throw new Error('Strict token validation requires discovery issuer and jwks_uri')
-        }
-        if (!strictValidation && issuer && !isIssuer(issuer)) {
-          throw new Error('OpenID configuration has invalid issuer metadata')
-        }
-        if (typeof jwksUri !== 'string' || !jwksUri) {
-          throw new Error('OpenID configuration is missing jwks_uri')
-        }
-        const commonValidationOptions = {
-          jwksUri,
-          ...((strictValidation ? isStrictIssuer(issuer) : isIssuer(issuer)) && { issuer }),
-          ...(strictValidation && { requiredClaims: ['exp'] }),
-        }
-        const legacyAudience = config.audience
-          ? { audience: [config.audience, config.clientId] }
-          : {}
-        tokens = {
-          accessToken: validateAccessToken
-            ? await validateToken(tokenResponse.access_token, {
-                ...commonValidationOptions,
-                ...(strictValidation ? { audience: config.audience } : legacyAudience),
-              })
-            : accessToken,
-          ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
-          ...(tokenResponse.id_token && {
-            idToken: validateIdToken
-              ? strictValidation
-                ? await validateOidcIdToken(
-                    tokenResponse.id_token,
-                    { ...commonValidationOptions, audience: config.clientId },
-                    config.clientId,
-                    session.data.nonce,
-                    config.nonce || config.responseType.includes('token'),
-                  )
-                : await validateToken(tokenResponse.id_token, {
-                    ...commonValidationOptions,
-                    ...legacyAudience,
-                  })
-              : idToken,
-          }),
-        }
-      } catch (error) {
-        return oidcErrorHandler(event, `[${provider}] Token validation failed: ${String(error)}`)
-      }
-    } else {
-      tokens = {
+    let legacyValidationSkipped: boolean
+    try {
+      const validationResult = await validateTokenResponse({
         accessToken,
-        ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
-        ...(idToken && { idToken }),
-      }
+        config,
+        customFetch,
+        expectedNonce: session.data.nonce,
+        idToken,
+        nonceRequired:
+          config.tokenValidationMode === 'strict' &&
+          (config.nonce || config.responseType.includes('token')),
+        tokenResponse,
+      })
+      tokens = validationResult.tokens
+      legacyValidationSkipped = validationResult.legacyValidationSkipped
+    } catch (error) {
+      return oidcErrorHandler(event, `[${provider}] Token validation failed: ${String(error)}`)
     }
 
-    if (
-      !strictValidation &&
-      ((config.validateAccessToken && !validateAccessToken) ||
-        (config.validateIdToken && !validateIdToken)) &&
-      !warnedLegacyValidationProviders.has(provider)
-    ) {
+    if (legacyValidationSkipped && !warnedLegacyValidationProviders.has(provider)) {
       warnedLegacyValidationProviders.add(provider)
       logger.warn(
         `[${provider}] Legacy token validation skipped an enabled token because no token audience matched or the token was unavailable. Configure tokenValidationMode: 'strict' to validate enabled JWT tokens without trusting decoded claims.`,

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -24,6 +24,7 @@ export async function refreshAccessToken(
   refreshToken: string,
   config: OidcProviderConfig,
   expectedSubject?: string,
+  expectedAuthenticationTime?: number,
 ) {
   const logger = useOidcLogger()
   const customFetch = await createProviderFetch(config)
@@ -84,6 +85,7 @@ export async function refreshAccessToken(
         accessToken,
         config,
         customFetch,
+        expectedAuthenticationTime,
         expectedSubject,
         idToken,
         tokenResponse,

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -1,4 +1,10 @@
-import type { RefreshTokenRequest, TokenRequest, TokenRespose, UserSession } from '../../types'
+import type {
+  RefreshTokenRequest,
+  TokenRequest,
+  TokenRespose,
+  Tokens,
+  UserSession,
+} from '../../types'
 import type { H3Event } from 'h3'
 import type { OidcProviderConfig } from './provider'
 import { createConsola } from 'consola'
@@ -8,6 +14,7 @@ import { textToBase64 } from './encoding'
 import { parseJwtToken } from './security'
 import { clearUserSession } from './session'
 import { snakeCase } from './string'
+import { validateTokenResponse } from './token-validation'
 
 export function useOidcLogger() {
   return createConsola().withDefaults({ tag: 'nuxt-oidc-auth', message: '[nuxt-oidc-auth]:' })
@@ -62,17 +69,39 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
   }
 
   const accessToken = parseJwtToken(tokenResponse.access_token, !!config.skipAccessTokenParsing)
+  const idToken =
+    tokenResponse.id_token && (config.tokenValidationMode === 'strict' || !!config.optionalClaims)
+      ? parseJwtToken(tokenResponse.id_token)
+      : undefined
+  let parsedTokens: Tokens
+  if (config.tokenValidationMode === 'strict') {
+    parsedTokens = (
+      await validateTokenResponse({
+        accessToken,
+        config,
+        customFetch,
+        idToken,
+        tokenResponse,
+      })
+    ).tokens
+  } else {
+    parsedTokens = {
+      accessToken,
+      ...(idToken && { idToken }),
+      ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
+    }
+  }
 
   // Construct user object
   const user: Omit<UserSession, 'provider'> = {
     canRefresh: !!tokens.refreshToken,
     updatedAt: Math.trunc(Date.now() / 1000), // Use seconds instead of milliseconds to align wih JWT
-    expireAt: accessToken.exp || Math.trunc(Date.now() / 1000) + 3600, // Fallback 60 min
+    expireAt: parsedTokens.accessToken.exp || Math.trunc(Date.now() / 1000) + 3600, // Fallback 60 min
   }
 
   // Update optional claims
-  if (config.optionalClaims && tokenResponse.id_token) {
-    const parsedIdToken = parseJwtToken(tokenResponse.id_token)
+  if (config.optionalClaims && parsedTokens.idToken) {
+    const parsedIdToken = parsedTokens.idToken
     user.claims = {}
     config.optionalClaims.forEach((claim) => {
       if (parsedIdToken[claim]) {
@@ -87,7 +116,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
     user,
     tokens,
     expiresIn: tokenResponse.expires_in,
-    parsedAccessToken: accessToken,
+    parsedAccessToken: parsedTokens.accessToken,
   }
 }
 

--- a/src/runtime/server/utils/oidc.ts
+++ b/src/runtime/server/utils/oidc.ts
@@ -20,7 +20,11 @@ export function useOidcLogger() {
   return createConsola().withDefaults({ tag: 'nuxt-oidc-auth', message: '[nuxt-oidc-auth]:' })
 }
 
-export async function refreshAccessToken(refreshToken: string, config: OidcProviderConfig) {
+export async function refreshAccessToken(
+  refreshToken: string,
+  config: OidcProviderConfig,
+  expectedSubject?: string,
+) {
   const logger = useOidcLogger()
   const customFetch = await createProviderFetch(config)
   // Construct request header object
@@ -80,6 +84,7 @@ export async function refreshAccessToken(refreshToken: string, config: OidcProvi
         accessToken,
         config,
         customFetch,
+        expectedSubject,
         idToken,
         tokenResponse,
       })

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -161,7 +161,7 @@ export interface OidcProviderConfig {
    */
   validateIdToken?: boolean
   /**
-   * Callback token validation behavior. Strict mode validates every enabled JWT in the initial token response without trusting decoded claims first.
+   * Token validation behavior. Strict mode validates every enabled JWT in callback and refresh token responses without trusting decoded claims first.
    * @default 'legacy'
    */
   tokenValidationMode?: 'legacy' | 'strict'

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -16,7 +16,7 @@ import { useStorage } from 'nitropack/runtime'
 import * as providerPresets from '../../providers'
 import { resolveProviderConfig, validateProviderConfig } from './config'
 import { refreshAccessToken, useOidcLogger } from './oidc'
-import { decryptToken, encryptToken } from './security'
+import { decryptToken, encryptToken, parseJwtToken } from './security'
 import { resolveMissingPersistentSessionMode } from './session-options'
 
 const DEFAULT_SESSION_NAME = 'nuxt-oidc-auth'
@@ -180,7 +180,22 @@ export async function refreshUserSession(event: H3Event, options: SessionBehavio
 
   let tokenRefreshResponse: Awaited<ReturnType<typeof refreshAccessToken>>
   try {
-    tokenRefreshResponse = await refreshAccessToken(refreshToken, config as OidcProviderConfig)
+    let expectedSubject: string | undefined
+    if (config.tokenValidationMode === 'strict' && config.validateIdToken) {
+      if (!persistentSession.idToken) {
+        throw new Error('Strict refresh validation requires the original ID token')
+      }
+      const originalIdToken = await decryptToken(persistentSession.idToken, tokenKey)
+      expectedSubject = parseJwtToken(originalIdToken).sub
+      if (typeof expectedSubject !== 'string' || expectedSubject.length === 0) {
+        throw new Error('Original ID token sub must be a non-empty string')
+      }
+    }
+    tokenRefreshResponse = await refreshAccessToken(
+      refreshToken,
+      config as OidcProviderConfig,
+      expectedSubject,
+    )
   } catch (error) {
     logger.error(`[${provider}] Token refresh failed: ${String(error)}`)
     await clearUserSession(event)

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -180,21 +180,31 @@ export async function refreshUserSession(event: H3Event, options: SessionBehavio
 
   let tokenRefreshResponse: Awaited<ReturnType<typeof refreshAccessToken>>
   try {
+    let expectedAuthenticationTime: number | undefined
     let expectedSubject: string | undefined
     if (config.tokenValidationMode === 'strict' && config.validateIdToken) {
       if (!persistentSession.idToken) {
         throw new Error('Strict refresh validation requires the original ID token')
       }
       const originalIdToken = await decryptToken(persistentSession.idToken, tokenKey)
-      expectedSubject = parseJwtToken(originalIdToken).sub
+      const originalIdTokenPayload = parseJwtToken(originalIdToken)
+      expectedSubject = originalIdTokenPayload.sub
       if (typeof expectedSubject !== 'string' || expectedSubject.length === 0) {
         throw new Error('Original ID token sub must be a non-empty string')
       }
+      if (
+        originalIdTokenPayload.auth_time !== undefined &&
+        typeof originalIdTokenPayload.auth_time !== 'number'
+      ) {
+        throw new Error('Original ID token auth_time must be a number')
+      }
+      expectedAuthenticationTime = originalIdTokenPayload.auth_time
     }
     tokenRefreshResponse = await refreshAccessToken(
       refreshToken,
       config as OidcProviderConfig,
       expectedSubject,
+      expectedAuthenticationTime,
     )
   } catch (error) {
     logger.error(`[${provider}] Token refresh failed: ${String(error)}`)

--- a/src/runtime/server/utils/token-validation.ts
+++ b/src/runtime/server/utils/token-validation.ts
@@ -1,0 +1,182 @@
+import type { TokenRespose, Tokens } from '../../types'
+import type { OidcProviderConfig, createProviderFetch } from './provider'
+import type { JwtPayload } from './security'
+import { validateToken } from './security'
+
+type ProviderFetch = Awaited<ReturnType<typeof createProviderFetch>>
+
+interface ValidateTokenResponseOptions {
+  accessToken: JwtPayload | Record<string, never>
+  config: OidcProviderConfig
+  customFetch: ProviderFetch
+  expectedNonce?: string
+  idToken?: JwtPayload | Record<string, never>
+  nonceRequired?: boolean
+  tokenResponse: TokenRespose
+}
+
+export interface TokenValidationResult {
+  legacyValidationSkipped: boolean
+  tokens: Tokens
+}
+
+function hasExactAudience(payload: JwtPayload | undefined, expectedAudiences: string[]): boolean {
+  if (typeof payload?.aud === 'string') return expectedAudiences.includes(payload.aud)
+  if (!Array.isArray(payload?.aud)) return false
+  return payload.aud.some(
+    (audience) => typeof audience === 'string' && expectedAudiences.includes(audience),
+  )
+}
+
+function isIssuer(value: unknown): value is string | string[] {
+  return (
+    typeof value === 'string' ||
+    (Array.isArray(value) && value.every((issuer) => typeof issuer === 'string'))
+  )
+}
+
+function isStrictIssuer(value: unknown): value is string | string[] {
+  return (
+    (typeof value === 'string' && value.trim().length > 0) ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((issuer) => typeof issuer === 'string' && issuer.trim().length > 0))
+  )
+}
+
+async function validateOidcIdToken(
+  token: string,
+  options: Parameters<typeof validateToken>[1],
+  clientId: string,
+  expectedNonce?: string,
+  nonceRequired = false,
+): Promise<JwtPayload> {
+  const payload = await validateToken(token, {
+    ...options,
+    requiredClaims: [...new Set([...(options.requiredClaims || []), 'sub', 'iat'])],
+  })
+  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+    throw new Error('ID token sub must be a non-empty string')
+  }
+  const authorizedParty = payload.azp
+  if (
+    (Array.isArray(payload.aud) && payload.aud.length > 1 && typeof authorizedParty !== 'string') ||
+    (authorizedParty !== undefined && authorizedParty !== clientId)
+  ) {
+    throw new Error('ID token azp must match clientId and is required for multiple audiences')
+  }
+  if (nonceRequired && (typeof expectedNonce !== 'string' || expectedNonce.length === 0)) {
+    throw new Error('Authentication session is missing the expected nonce')
+  }
+  if (nonceRequired && payload.nonce !== expectedNonce) {
+    throw new Error('ID token nonce must match the authentication request')
+  }
+  return payload
+}
+
+export async function validateTokenResponse({
+  accessToken,
+  config,
+  customFetch,
+  expectedNonce,
+  idToken,
+  nonceRequired = false,
+  tokenResponse,
+}: ValidateTokenResponseOptions): Promise<TokenValidationResult> {
+  const strictValidation = config.tokenValidationMode === 'strict'
+  if (
+    strictValidation &&
+    (typeof tokenResponse.access_token !== 'string' || tokenResponse.access_token.length === 0)
+  ) {
+    throw new Error('Missing access token')
+  }
+  if (strictValidation && config.validateIdToken && !tokenResponse.id_token) {
+    throw new Error('Missing ID token')
+  }
+
+  const legacyAudiences = [config.audience, config.clientId].filter(
+    (audience): audience is string => !!audience,
+  )
+  const legacyAudienceMatched =
+    !strictValidation &&
+    (hasExactAudience(accessToken, legacyAudiences) || hasExactAudience(idToken, legacyAudiences))
+  const validateAccessToken =
+    !!config.validateAccessToken && (strictValidation || legacyAudienceMatched)
+  const validateIdToken =
+    !!config.validateIdToken &&
+    !!tokenResponse.id_token &&
+    (strictValidation || legacyAudienceMatched)
+
+  let tokens: Tokens
+  if (validateAccessToken || validateIdToken) {
+    const openIdConfiguration =
+      config.openIdConfiguration && typeof config.openIdConfiguration === 'object'
+        ? config.openIdConfiguration
+        : typeof config.openIdConfiguration === 'string'
+          ? await customFetch<Record<string, unknown>>(config.openIdConfiguration)
+          : await config.openIdConfiguration!(config)
+    const issuer = openIdConfiguration.issuer
+    const jwksUri = openIdConfiguration.jwks_uri
+    if (strictValidation && (!isStrictIssuer(issuer) || typeof jwksUri !== 'string' || !jwksUri)) {
+      throw new Error('Strict token validation requires discovery issuer and jwks_uri')
+    }
+    if (!strictValidation && issuer && !isIssuer(issuer)) {
+      throw new Error('OpenID configuration has invalid issuer metadata')
+    }
+    if (typeof jwksUri !== 'string' || !jwksUri) {
+      throw new Error('OpenID configuration is missing jwks_uri')
+    }
+    const validatedIssuer = strictValidation
+      ? isStrictIssuer(issuer)
+        ? issuer
+        : undefined
+      : isIssuer(issuer)
+        ? issuer
+        : undefined
+    const commonValidationOptions = {
+      jwksUri,
+      ...(validatedIssuer !== undefined && { issuer: validatedIssuer }),
+      ...(strictValidation && { requiredClaims: ['exp'] }),
+    }
+    const legacyAudience = config.audience ? { audience: [config.audience, config.clientId] } : {}
+    tokens = {
+      accessToken: validateAccessToken
+        ? await validateToken(tokenResponse.access_token, {
+            ...commonValidationOptions,
+            ...(strictValidation ? { audience: config.audience } : legacyAudience),
+          })
+        : accessToken,
+      ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
+      ...(tokenResponse.id_token && {
+        idToken: validateIdToken
+          ? strictValidation
+            ? await validateOidcIdToken(
+                tokenResponse.id_token,
+                { ...commonValidationOptions, audience: config.clientId },
+                config.clientId,
+                expectedNonce,
+                nonceRequired,
+              )
+            : await validateToken(tokenResponse.id_token, {
+                ...commonValidationOptions,
+                ...legacyAudience,
+              })
+          : idToken,
+      }),
+    }
+  } else {
+    tokens = {
+      accessToken,
+      ...(tokenResponse.refresh_token && { refreshToken: tokenResponse.refresh_token }),
+      ...(idToken && { idToken }),
+    }
+  }
+
+  return {
+    legacyValidationSkipped:
+      !strictValidation &&
+      ((!!config.validateAccessToken && !validateAccessToken) ||
+        (!!config.validateIdToken && !validateIdToken)),
+    tokens,
+  }
+}

--- a/src/runtime/server/utils/token-validation.ts
+++ b/src/runtime/server/utils/token-validation.ts
@@ -9,6 +9,7 @@ interface ValidateTokenResponseOptions {
   accessToken: JwtPayload | Record<string, never>
   config: OidcProviderConfig
   customFetch: ProviderFetch
+  expectedAuthenticationTime?: number
   expectedNonce?: string
   expectedSubject?: string
   idToken?: JwtPayload | Record<string, never>
@@ -49,6 +50,7 @@ async function validateOidcIdToken(
   token: string,
   options: Parameters<typeof validateToken>[1],
   clientId: string,
+  expectedAuthenticationTime?: number,
   expectedNonce?: string,
   nonceRequired = false,
   expectedSubject?: string,
@@ -62,6 +64,12 @@ async function validateOidcIdToken(
   }
   if (expectedSubject !== undefined && payload.sub !== expectedSubject) {
     throw new Error('Refreshed ID token sub must match the original ID token')
+  }
+  if (
+    expectedAuthenticationTime !== undefined &&
+    payload.auth_time !== expectedAuthenticationTime
+  ) {
+    throw new Error('Refreshed ID token auth_time must match the original ID token')
   }
   const authorizedParty = payload.azp
   if (
@@ -83,6 +91,7 @@ export async function validateTokenResponse({
   accessToken,
   config,
   customFetch,
+  expectedAuthenticationTime,
   expectedNonce,
   expectedSubject,
   idToken,
@@ -160,6 +169,7 @@ export async function validateTokenResponse({
                 tokenResponse.id_token,
                 { ...commonValidationOptions, audience: config.clientId },
                 config.clientId,
+                expectedAuthenticationTime,
                 expectedNonce,
                 nonceRequired,
                 expectedSubject,

--- a/src/runtime/server/utils/token-validation.ts
+++ b/src/runtime/server/utils/token-validation.ts
@@ -10,6 +10,7 @@ interface ValidateTokenResponseOptions {
   config: OidcProviderConfig
   customFetch: ProviderFetch
   expectedNonce?: string
+  expectedSubject?: string
   idToken?: JwtPayload | Record<string, never>
   nonceRequired?: boolean
   tokenResponse: TokenRespose
@@ -50,6 +51,7 @@ async function validateOidcIdToken(
   clientId: string,
   expectedNonce?: string,
   nonceRequired = false,
+  expectedSubject?: string,
 ): Promise<JwtPayload> {
   const payload = await validateToken(token, {
     ...options,
@@ -57,6 +59,9 @@ async function validateOidcIdToken(
   })
   if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
     throw new Error('ID token sub must be a non-empty string')
+  }
+  if (expectedSubject !== undefined && payload.sub !== expectedSubject) {
+    throw new Error('Refreshed ID token sub must match the original ID token')
   }
   const authorizedParty = payload.azp
   if (
@@ -79,6 +84,7 @@ export async function validateTokenResponse({
   config,
   customFetch,
   expectedNonce,
+  expectedSubject,
   idToken,
   nonceRequired = false,
   tokenResponse,
@@ -156,6 +162,7 @@ export async function validateTokenResponse({
                 config.clientId,
                 expectedNonce,
                 nonceRequired,
+                expectedSubject,
               )
             : await validateToken(tokenResponse.id_token, {
                 ...commonValidationOptions,

--- a/test/functional/refresh-validation.test.ts
+++ b/test/functional/refresh-validation.test.ts
@@ -81,11 +81,19 @@ async function invokeRefresh(
   tokenResponse: Record<string, unknown>,
   overrides: Partial<OidcProviderConfig> = {},
   originalSubject: string | null = 'user-1',
+  originalAuthenticationTime?: number,
 ) {
   const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig(overrides) })
   const sessionId = 'refresh-validation-session'
   const originalIdToken = originalSubject
-    ? await signingFixture.sign({ aud: clientId, iss: issuer, sub: originalSubject })
+    ? await signingFixture.sign({
+        aud: clientId,
+        iss: issuer,
+        sub: originalSubject,
+        ...(originalAuthenticationTime !== undefined && {
+          auth_time: originalAuthenticationTime,
+        }),
+      })
     : undefined
   mocks.decryptToken.mockImplementation(async (token) =>
     token.encryptedToken === 'encrypted-id-token' && originalIdToken
@@ -264,6 +272,36 @@ describe('strict refresh token validation', () => {
     expect(result).toMatchObject({ statusCode: 401 })
     expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
     expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('rejects a changed ID token authentication time', async () => {
+    const response = await validTokenResponse()
+    response.id_token = await signingFixture.sign({
+      aud: clientId,
+      auth_time: 200,
+      iss: issuer,
+      sub: 'user-1',
+    })
+
+    const { harness, result, sessionId } = await invokeRefresh(response, {}, 'user-1', 100)
+
+    expect(result).toMatchObject({ statusCode: 401 })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('accepts an unchanged ID token authentication time', async () => {
+    const response = await validTokenResponse()
+    response.id_token = await signingFixture.sign({
+      aud: clientId,
+      auth_time: 100,
+      iss: issuer,
+      sub: 'user-1',
+    })
+
+    const { result } = await invokeRefresh(response, {}, 'user-1', 100)
+
+    expect(result).toEqual(expect.objectContaining({ provider: 'oidc' }))
   })
 
   it('supports an opaque access token while validating the ID token', async () => {

--- a/test/functional/refresh-validation.test.ts
+++ b/test/functional/refresh-validation.test.ts
@@ -1,0 +1,312 @@
+import type * as SecurityUtils from '../../src/runtime/server/utils/security'
+import type { OidcProviderConfig } from '../../src/runtime/server/utils/provider'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+const issuer = 'https://identity.example.test'
+const tokenUrl = `${issuer}/token`
+const jwksUri = `${issuer}/jwks`
+const clientId = 'functional-client'
+const audience = 'functional-api'
+let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+let untrustedSigningFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+
+const mocks = vi.hoisted(() => ({
+  decryptToken: vi.fn<() => Promise<string>>(),
+  encryptToken: vi.fn<() => Promise<{ encryptedToken: string; iv: string }>>(),
+}))
+
+vi.mock('../../src/runtime/server/utils/security', async (importOriginal) => {
+  const actual = await importOriginal<typeof SecurityUtils>()
+  return {
+    ...actual,
+    decryptToken: mocks.decryptToken,
+    encryptToken: mocks.encryptToken,
+  }
+})
+
+beforeAll(async () => {
+  signingFixture = await createRs256Fixture()
+  untrustedSigningFixture = await createRs256Fixture()
+})
+
+beforeEach(() => {
+  mocks.decryptToken.mockResolvedValue('refresh-token')
+  mocks.encryptToken.mockResolvedValue({ encryptedToken: 'encrypted', iv: 'iv' })
+  vi.stubEnv('NUXT_OIDC_SESSION_SECRET', 'test-session-secret-at-least-32-characters')
+  vi.stubEnv('NUXT_OIDC_TOKEN_KEY', 'test-token-key')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+function createRuntimeConfig(overrides: Partial<OidcProviderConfig> = {}) {
+  return {
+    oidc: {
+      session: {
+        maxAge: 3600,
+        automaticRefresh: false,
+        expirationCheck: false,
+      },
+      providers: {
+        oidc: {
+          clientId,
+          clientSecret: 'functional-secret',
+          authorizationUrl: `${issuer}/authorize`,
+          tokenUrl,
+          redirectUri: 'https://app.example.test/auth/oidc/callback',
+          audience,
+          tokenValidationMode: 'strict',
+          validateAccessToken: true,
+          validateIdToken: true,
+          openIdConfiguration: { issuer, jwks_uri: jwksUri },
+          optionalClaims: ['role'],
+          requiredProperties: [
+            'clientId',
+            'clientSecret',
+            'authorizationUrl',
+            'tokenUrl',
+            'redirectUri',
+          ],
+          ...overrides,
+        },
+      },
+    },
+  }
+}
+
+async function invokeRefresh(
+  tokenResponse: Record<string, unknown>,
+  overrides: Partial<OidcProviderConfig> = {},
+) {
+  const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig(overrides) })
+  const sessionId = 'refresh-validation-session'
+  harness.cookieJar.seedSession(
+    'nuxt-oidc-auth',
+    {
+      provider: 'oidc',
+      canRefresh: true,
+      expireAt: 1,
+      loggedInAt: 1,
+      updatedAt: 1,
+      claims: { role: 'old-role' },
+    },
+    sessionId,
+  )
+  await harness.storage('oidc').setItem(sessionId, {
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    exp: 1,
+    iat: 1,
+    accessToken: { encryptedToken: 'encrypted', iv: 'iv' },
+    refreshToken: { encryptedToken: 'encrypted', iv: 'iv' },
+  })
+  const interceptor = interceptFetch([
+    {
+      method: 'POST',
+      url: tokenUrl,
+      respond: () => Response.json(tokenResponse),
+    },
+    { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+  ])
+  const request = harness.createEvent({ path: '/api/_auth/session/refresh' })
+  const { refreshUserSession } = await import('../../src/runtime/server/utils/session')
+  const result = await refreshUserSession(request.event).catch((error: unknown) => error)
+
+  return { harness, interceptor, result, sessionId }
+}
+
+async function validTokenResponse() {
+  return {
+    access_token: await signingFixture.sign({ aud: audience, iss: issuer, sub: 'user-1' }),
+    id_token: await signingFixture.sign({
+      aud: clientId,
+      iss: issuer,
+      role: 'current-role',
+      sub: 'user-1',
+    }),
+    refresh_token: 'rotated-refresh-token',
+    token_type: 'Bearer',
+    expires_in: '3600',
+  }
+}
+
+describe('strict refresh token validation', () => {
+  it('validates refreshed JWTs before updating session state', async () => {
+    const { harness, result, sessionId } = await invokeRefresh(await validTokenResponse())
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        provider: 'oidc',
+        claims: { role: 'current-role' },
+      }),
+    )
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual(
+      expect.objectContaining({ claims: { role: 'current-role' } }),
+    )
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(true)
+  })
+
+  it.each([
+    {
+      name: 'access token signature',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        access_token: await untrustedSigningFixture.sign({
+          aud: audience,
+          iss: issuer,
+          sub: 'user-1',
+        }),
+      }),
+    },
+    {
+      name: 'access token issuer',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        access_token: await signingFixture.sign({
+          aud: audience,
+          iss: 'https://attacker.example.test',
+          sub: 'user-1',
+        }),
+      }),
+    },
+    {
+      name: 'access token expiration',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        access_token: await signingFixture.sign({
+          aud: audience,
+          exp: 0,
+          iss: issuer,
+          sub: 'user-1',
+        }),
+      }),
+    },
+    {
+      name: 'access token audience',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        access_token: await signingFixture.sign({ aud: clientId, iss: issuer, sub: 'user-1' }),
+      }),
+    },
+    {
+      name: 'ID token audience',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        id_token: await signingFixture.sign({ aud: audience, iss: issuer, sub: 'user-1' }),
+      }),
+    },
+    {
+      name: 'ID token signature',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        id_token: await untrustedSigningFixture.sign({ aud: clientId, iss: issuer, sub: 'user-1' }),
+      }),
+    },
+    {
+      name: 'ID token issuer',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        id_token: await signingFixture.sign({
+          aud: clientId,
+          iss: 'https://attacker.example.test',
+          sub: 'user-1',
+        }),
+      }),
+    },
+    {
+      name: 'ID token expiration',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        id_token: await signingFixture.sign({ aud: clientId, exp: 0, iss: issuer, sub: 'user-1' }),
+      }),
+    },
+  ])('clears the session after rejecting an invalid $name', async ({ createResponse }) => {
+    const { harness, result, sessionId } = await invokeRefresh(await createResponse())
+
+    expect(result).toMatchObject({ statusCode: 401 })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('requires an enabled ID token in the refresh response', async () => {
+    const { id_token: _, ...response } = await validTokenResponse()
+
+    const { harness, result, sessionId } = await invokeRefresh(response)
+
+    expect(result).toMatchObject({ statusCode: 401 })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('supports an opaque access token while validating the ID token', async () => {
+    const response = await validTokenResponse()
+    response.access_token = 'opaque-access-token'
+
+    const { harness, result } = await invokeRefresh(response, {
+      skipAccessTokenParsing: true,
+      validateAccessToken: false,
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        provider: 'oidc',
+        claims: { role: 'current-role' },
+      }),
+    )
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).not.toEqual({})
+  })
+
+  it.each([
+    {
+      name: 'missing',
+      createResponse: async () => {
+        const { access_token: _, ...response } = await validTokenResponse()
+        return response
+      },
+    },
+    {
+      name: 'empty',
+      createResponse: async () => ({ ...(await validTokenResponse()), access_token: '' }),
+    },
+    {
+      name: 'non-string',
+      createResponse: async () => ({ ...(await validTokenResponse()), access_token: {} }),
+    },
+  ])('rejects a $name opaque access token', async ({ createResponse }) => {
+    const { harness, result, sessionId } = await invokeRefresh(await createResponse(), {
+      skipAccessTokenParsing: true,
+      validateAccessToken: false,
+    })
+
+    expect(result).toMatchObject({ statusCode: 401 })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('preserves legacy refresh parsing without signature validation', async () => {
+    const response = await validTokenResponse()
+    response.access_token = await untrustedSigningFixture.sign({
+      aud: audience,
+      iss: issuer,
+      sub: 'user-1',
+    })
+    response.id_token = await untrustedSigningFixture.sign({
+      aud: clientId,
+      iss: issuer,
+      role: 'legacy-role',
+      sub: 'user-1',
+    })
+
+    const { interceptor, result } = await invokeRefresh(response, {
+      tokenValidationMode: 'legacy',
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({ claims: { role: 'legacy-role' }, provider: 'oidc' }),
+    )
+    expect(interceptor.requests.map((request) => request.url)).toEqual([tokenUrl])
+  })
+})

--- a/test/functional/refresh-validation.test.ts
+++ b/test/functional/refresh-validation.test.ts
@@ -12,7 +12,7 @@ let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
 let untrustedSigningFixture: Awaited<ReturnType<typeof createRs256Fixture>>
 
 const mocks = vi.hoisted(() => ({
-  decryptToken: vi.fn<() => Promise<string>>(),
+  decryptToken: vi.fn<(token: { encryptedToken: string }) => Promise<string>>(),
   encryptToken: vi.fn<() => Promise<{ encryptedToken: string; iv: string }>>(),
 }))
 
@@ -80,9 +80,18 @@ function createRuntimeConfig(overrides: Partial<OidcProviderConfig> = {}) {
 async function invokeRefresh(
   tokenResponse: Record<string, unknown>,
   overrides: Partial<OidcProviderConfig> = {},
+  originalSubject: string | null = 'user-1',
 ) {
   const harness = new HandlerHarness({ runtimeConfig: createRuntimeConfig(overrides) })
   const sessionId = 'refresh-validation-session'
+  const originalIdToken = originalSubject
+    ? await signingFixture.sign({ aud: clientId, iss: issuer, sub: originalSubject })
+    : undefined
+  mocks.decryptToken.mockImplementation(async (token) =>
+    token.encryptedToken === 'encrypted-id-token' && originalIdToken
+      ? originalIdToken
+      : 'refresh-token',
+  )
   harness.cookieJar.seedSession(
     'nuxt-oidc-auth',
     {
@@ -101,6 +110,7 @@ async function invokeRefresh(
     exp: 1,
     iat: 1,
     accessToken: { encryptedToken: 'encrypted', iv: 'iv' },
+    ...(originalIdToken && { idToken: { encryptedToken: 'encrypted-id-token', iv: 'iv' } }),
     refreshToken: { encryptedToken: 'encrypted', iv: 'iv' },
   })
   const interceptor = interceptFetch([
@@ -223,6 +233,13 @@ describe('strict refresh token validation', () => {
         id_token: await signingFixture.sign({ aud: clientId, exp: 0, iss: issuer, sub: 'user-1' }),
       }),
     },
+    {
+      name: 'ID token subject',
+      createResponse: async () => ({
+        ...(await validTokenResponse()),
+        id_token: await signingFixture.sign({ aud: clientId, iss: issuer, sub: 'other-user' }),
+      }),
+    },
   ])('clears the session after rejecting an invalid $name', async ({ createResponse }) => {
     const { harness, result, sessionId } = await invokeRefresh(await createResponse())
 
@@ -235,6 +252,14 @@ describe('strict refresh token validation', () => {
     const { id_token: _, ...response } = await validTokenResponse()
 
     const { harness, result, sessionId } = await invokeRefresh(response)
+
+    expect(result).toMatchObject({ statusCode: 401 })
+    expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})
+    expect(harness.inspectStorage('oidc').has(sessionId)).toBe(false)
+  })
+
+  it('requires the original ID token subject before strict refresh validation', async () => {
+    const { harness, result, sessionId } = await invokeRefresh(await validTokenResponse(), {}, null)
 
     expect(result).toMatchObject({ statusCode: 401 })
     expect(harness.inspectSession('nuxt-oidc-auth')?.data).toEqual({})


### PR DESCRIPTION
## Summary

- validate every enabled JWT returned by strict-mode token refresh before updating session state
- share signature, issuer, expiration, audience, and ID-token validation policy between callback and refresh flows
- preserve original ID-token subject and authentication time across refresh
- reject missing or malformed strict refresh tokens through existing session cleanup
- preserve legacy refresh parsing and opaque access-token opt-outs
- document strict callback and refresh guarantees

## Root cause

`tokenValidationMode: 'strict'` covered callback token responses, but refreshed tokens were only decoded before replacing persistent and cookie-session data. A token endpoint response with an invalid signature, issuer, expiration, audience, or changed ID-token identity could therefore update an authenticated session after refresh.

## Compatibility

`legacy` remains default and retains existing refresh parsing behavior. Opaque access tokens remain supported with `validateAccessToken: false` and `skipAccessTokenParsing: true`; strict mode still requires a present non-empty access-token value. No provider-specific branching or dependency changes.

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 85/85 passed
- focused callback, refresh, and session coverage - 66/66 passed
- serial E2E with Nix Chrome - 32 passed; 32 provider-configured skips
- `pnpm prepack` - passed
- independent xhigh security review - no remaining blockers

Closes #191
Tracks #179