### PR TITLE
test(config): verify production runtime overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **auth:** Validate strict-mode refresh token responses
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
+- **config:** Resolve provider environment overrides before deriving runtime endpoints
 
 ## v1.0.0-beta.11
 

--- a/test/e2e/flows/runtime-config.test.ts
+++ b/test/e2e/flows/runtime-config.test.ts
@@ -20,6 +20,8 @@ test.use({
       NUXT_OIDC_PROVIDERS_AUTH0_CLIENT_ID: 'runtime-auth0-client',
       NUXT_OIDC_PROVIDERS_AUTH0_CLIENT_SECRET: 'runtime-auth0-secret',
       NUXT_OIDC_PROVIDERS_AUTH0_REDIRECT_URI: 'https://app.example.test/auth/auth0/callback',
+      NUXT_OIDC_PROVIDERS_GITHUB_CLIENT_ID: 'runtime-github-client',
+      NUXT_OIDC_PROVIDERS_GITHUB_CLIENT_SECRET: 'runtime-github-secret',
       NUXT_OIDC_SESSION_SECRET: 'runtime-user-session-secret-at-least-48-characters-long',
       NUXT_OIDC_TOKEN_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
     },
@@ -57,13 +59,14 @@ test.describe('production runtime provider configuration', () => {
     )
   })
 
-  test('preserves static provider configuration', async () => {
+  test('preserves static provider fields alongside runtime overrides', async () => {
     const location = await getAuthorizationRedirect('github')
 
     expect(location.origin + location.pathname).toBe('https://github.com/login/oauth/authorize')
-    expect(location.searchParams.get('client_id')).toBe('static-client')
+    expect(location.searchParams.get('client_id')).toBe('runtime-github-client')
     expect(location.searchParams.get('redirect_uri')).toBe(
       'https://app.example.test/auth/github/callback',
     )
+    expect(location.searchParams.get('scope')).toBe('user:email')
   })
 })

--- a/test/e2e/flows/runtime-config.test.ts
+++ b/test/e2e/flows/runtime-config.test.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'node:url'
+import { url } from '@nuxt/test-utils/e2e'
+import { expect, test } from '@nuxt/test-utils/playwright'
+
+const runtimeKeycloakBaseUrl = 'https://runtime-keycloak.example.test/realms/production'
+const runtimeAuth0AuthorizationUrl = 'https://login.example.test/oauth/authorize'
+
+test.use({
+  nuxt: {
+    rootDir: fileURLToPath(new URL('../../fixtures/runtimeConfigApp', import.meta.url)),
+    build: true,
+    env: {
+      NUXT_OIDC_AUTH_SESSION_SECRET: 'runtime-auth-session-secret-at-least-48-characters-long',
+      NUXT_OIDC_PROVIDERS_KEYCLOAK_BASE_URL: runtimeKeycloakBaseUrl,
+      NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID: 'runtime-keycloak-client',
+      NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET: 'runtime-keycloak-secret',
+      NUXT_OIDC_PROVIDERS_KEYCLOAK_REDIRECT_URI: 'https://app.example.test/auth/keycloak/callback',
+      NUXT_OIDC_PROVIDERS_AUTH0_AUTHORIZATION_URL: runtimeAuth0AuthorizationUrl,
+      NUXT_OIDC_PROVIDERS_AUTH0_BASE_URL: 'https://runtime-auth0.example.test',
+      NUXT_OIDC_PROVIDERS_AUTH0_CLIENT_ID: 'runtime-auth0-client',
+      NUXT_OIDC_PROVIDERS_AUTH0_CLIENT_SECRET: 'runtime-auth0-secret',
+      NUXT_OIDC_PROVIDERS_AUTH0_REDIRECT_URI: 'https://app.example.test/auth/auth0/callback',
+      NUXT_OIDC_SESSION_SECRET: 'runtime-user-session-secret-at-least-48-characters-long',
+      NUXT_OIDC_TOKEN_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    },
+  },
+})
+
+async function getAuthorizationRedirect(provider: string): Promise<URL> {
+  const response = await fetch(url(`/auth/${provider}/login`), { redirect: 'manual' })
+
+  expect(response.status).toBe(302)
+  const location = response.headers.get('location')
+  if (!location) throw new Error('Missing authorization redirect location')
+  return new URL(location)
+}
+
+test.describe('production runtime provider configuration', () => {
+  test('derives omitted endpoints from runtime baseUrl', async () => {
+    const location = await getAuthorizationRedirect('keycloak')
+
+    expect(location.origin).toBe('https://runtime-keycloak.example.test')
+    expect(location.pathname).toBe('/realms/production/protocol/openid-connect/auth')
+    expect(location.searchParams.get('client_id')).toBe('runtime-keycloak-client')
+    expect(location.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.test/auth/keycloak/callback',
+    )
+  })
+
+  test('uses explicit runtime endpoint overrides', async () => {
+    const location = await getAuthorizationRedirect('auth0')
+
+    expect(location.origin + location.pathname).toBe(runtimeAuth0AuthorizationUrl)
+    expect(location.searchParams.get('client_id')).toBe('runtime-auth0-client')
+    expect(location.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.test/auth/auth0/callback',
+    )
+  })
+
+  test('preserves static provider configuration', async () => {
+    const location = await getAuthorizationRedirect('github')
+
+    expect(location.origin + location.pathname).toBe('https://github.com/login/oauth/authorize')
+    expect(location.searchParams.get('client_id')).toBe('static-client')
+    expect(location.searchParams.get('redirect_uri')).toBe(
+      'https://app.example.test/auth/github/callback',
+    )
+  })
+})

--- a/test/fixtures/runtimeConfigApp/app.vue
+++ b/test/fixtures/runtimeConfigApp/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Runtime Config Test App</div>
+</template>

--- a/test/fixtures/runtimeConfigApp/nuxt.config.ts
+++ b/test/fixtures/runtimeConfigApp/nuxt.config.ts
@@ -1,0 +1,52 @@
+import { defineNuxtConfig } from 'nuxt/config'
+import nuxtOidcAuth from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [nuxtOidcAuth],
+
+  telemetry: {
+    enabled: false,
+  },
+
+  oidc: {
+    defaultProvider: 'keycloak',
+    providers: {
+      keycloak: {
+        baseUrl: '',
+        clientId: '',
+        clientSecret: '',
+        redirectUri: '',
+      },
+      auth0: {
+        baseUrl: '',
+        clientId: '',
+        clientSecret: '',
+        redirectUri: '',
+      },
+      github: {
+        clientId: 'static-client',
+        clientSecret: 'static-secret',
+        redirectUri: 'https://app.example.test/auth/github/callback',
+      },
+    },
+    middleware: {
+      globalMiddlewareEnabled: false,
+    },
+    provideDefaultSecrets: false,
+  },
+
+  devtools: {
+    enabled: false,
+  },
+
+  nitro: {
+    preset: 'node-server',
+    storage: {
+      oidc: {
+        driver: 'memory',
+      },
+    },
+  },
+
+  compatibilityDate: '2024-08-28',
+})


### PR DESCRIPTION
## Summary

- build a production Nitro fixture with empty and omitted provider configuration
- inject provider values only when starting the built server
- verify runtime base URL endpoint derivation without a local redirect loop
- verify omitted explicit endpoint overrides take precedence over derived preset endpoints
- preserve static provider configuration
- add runtime endpoint resolution to Unreleased changelog

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 85/85 passed
- focused production E2E with Nix Chrome - 3/3 passed
- full serial E2E with Nix Chrome - 35 passed; 32 provider-configured skips
- `pnpm prepack` - passed
- independent runtime-config review - no remaining blockers

Closes #120
Tracks #179