### PR TITLE
test(session): verify token exposure overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 - **config:** Resolve provider environment overrides before deriving runtime endpoints
+- **session:** Respect explicit token exposure overrides
 
 ## v1.0.0-beta.11
 

--- a/test/functional/token-exposure.test.ts
+++ b/test/functional/token-exposure.test.ts
@@ -103,18 +103,21 @@ function expectTokenExposure(
 describe('token exposure overrides', () => {
   it.each([
     {
+      id: 'explicit-true',
       name: 'explicit true values',
       overrides: { exposeAccessToken: true, exposeIdToken: true },
       exposeAccessToken: true,
       exposeIdToken: true,
     },
     {
+      id: 'explicit-false',
       name: 'explicit false values',
       overrides: { exposeAccessToken: false, exposeIdToken: false },
       exposeAccessToken: false,
       exposeIdToken: false,
     },
     {
+      id: 'omitted',
       name: 'omitted values',
       overrides: {},
       exposeAccessToken: false,
@@ -124,7 +127,7 @@ describe('token exposure overrides', () => {
     const initialHarness = new HandlerHarness({
       runtimeConfig: createRuntimeConfig(testCase.overrides),
     })
-    await seedSession(initialHarness, `initial-${testCase.name}`)
+    await seedSession(initialHarness, `initial-${testCase.id}`)
     const { getUserSession, refreshUserSession } =
       await import('../../src/runtime/server/utils/session')
     const initialRequest = initialHarness.createEvent({ path: '/api/_auth/session' })
@@ -140,7 +143,7 @@ describe('token exposure overrides', () => {
     const refreshHarness = new HandlerHarness({
       runtimeConfig: createRuntimeConfig(testCase.overrides),
     })
-    await seedSession(refreshHarness, `refresh-${testCase.name}`)
+    await seedSession(refreshHarness, `refresh-${testCase.id}`)
     interceptFetch([
       {
         method: 'POST',

--- a/test/functional/token-exposure.test.ts
+++ b/test/functional/token-exposure.test.ts
@@ -1,0 +1,166 @@
+import type { OidcProviderConfig } from '../../src/runtime/server/utils/provider'
+import type * as SecurityUtils from '../../src/runtime/server/utils/security'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+const baseUrl = 'https://identity.example.test/realms/example'
+const tokenUrl = `${baseUrl}/protocol/openid-connect/token`
+let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+
+const mocks = vi.hoisted(() => ({
+  decryptToken: vi.fn<(token: { encryptedToken: string }) => Promise<string>>(),
+  encryptToken: vi.fn<() => Promise<{ encryptedToken: string; iv: string }>>(),
+}))
+
+vi.mock('../../src/runtime/server/utils/security', async (importOriginal) => {
+  const actual = await importOriginal<typeof SecurityUtils>()
+  return {
+    ...actual,
+    decryptToken: mocks.decryptToken,
+    encryptToken: mocks.encryptToken,
+  }
+})
+
+beforeAll(async () => {
+  signingFixture = await createRs256Fixture()
+})
+
+beforeEach(() => {
+  mocks.decryptToken.mockImplementation(async (token) => {
+    if (token.encryptedToken === 'stored-access-token') return 'initial-access-token'
+    if (token.encryptedToken === 'stored-id-token') return 'initial-id-token'
+    return 'refresh-token'
+  })
+  mocks.encryptToken.mockResolvedValue({ encryptedToken: 'encrypted', iv: 'iv' })
+  vi.stubEnv('NUXT_OIDC_SESSION_SECRET', 'test-session-secret-at-least-32-characters')
+  vi.stubEnv('NUXT_OIDC_TOKEN_KEY', 'test-token-key')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+type ExposureOverrides = Pick<OidcProviderConfig, 'exposeAccessToken' | 'exposeIdToken'>
+
+function createRuntimeConfig(overrides: Partial<ExposureOverrides>) {
+  return {
+    oidc: {
+      session: {
+        maxAge: 3600,
+        automaticRefresh: false,
+        expirationCheck: false,
+      },
+      providers: {
+        keycloak: {
+          baseUrl,
+          clientId: 'functional-client',
+          clientSecret: 'functional-secret',
+          redirectUri: 'https://app.example.test/auth/keycloak/callback',
+          validateAccessToken: false,
+          validateIdToken: false,
+          ...overrides,
+        },
+      },
+    },
+  }
+}
+
+async function seedSession(harness: HandlerHarness, sessionId: string): Promise<void> {
+  const now = Math.trunc(Date.now() / 1000)
+  harness.cookieJar.seedSession(
+    'nuxt-oidc-auth',
+    {
+      provider: 'keycloak',
+      canRefresh: true,
+      expireAt: now + 3600,
+      loggedInAt: now,
+    },
+    sessionId,
+  )
+  await harness.storage('oidc').setItem(sessionId, {
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    exp: now + 3600,
+    iat: now,
+    accessToken: { encryptedToken: 'stored-access-token', iv: 'iv' },
+    idToken: { encryptedToken: 'stored-id-token', iv: 'iv' },
+    refreshToken: { encryptedToken: 'stored-refresh-token', iv: 'iv' },
+  })
+}
+
+function expectTokenExposure(
+  session: { accessToken?: string; idToken?: string },
+  expected: { accessToken?: string; idToken?: string },
+): void {
+  if (expected.accessToken) expect(session.accessToken).toBe(expected.accessToken)
+  else expect(session).not.toHaveProperty('accessToken')
+
+  if (expected.idToken) expect(session.idToken).toBe(expected.idToken)
+  else expect(session).not.toHaveProperty('idToken')
+}
+
+describe('token exposure overrides', () => {
+  it.each([
+    {
+      name: 'explicit true values',
+      overrides: { exposeAccessToken: true, exposeIdToken: true },
+      exposeAccessToken: true,
+      exposeIdToken: true,
+    },
+    {
+      name: 'explicit false values',
+      overrides: { exposeAccessToken: false, exposeIdToken: false },
+      exposeAccessToken: false,
+      exposeIdToken: false,
+    },
+    {
+      name: 'omitted values',
+      overrides: {},
+      exposeAccessToken: false,
+      exposeIdToken: true,
+    },
+  ])('applies $name to initial and refreshed sessions', async (testCase) => {
+    const initialHarness = new HandlerHarness({
+      runtimeConfig: createRuntimeConfig(testCase.overrides),
+    })
+    await seedSession(initialHarness, `initial-${testCase.name}`)
+    const { getUserSession, refreshUserSession } =
+      await import('../../src/runtime/server/utils/session')
+    const initialRequest = initialHarness.createEvent({ path: '/api/_auth/session' })
+    const initialSession = await getUserSession(initialRequest.event)
+
+    expectTokenExposure(initialSession, {
+      ...(testCase.exposeAccessToken && { accessToken: 'initial-access-token' }),
+      ...(testCase.exposeIdToken && { idToken: 'initial-id-token' }),
+    })
+
+    const refreshedAccessToken = await signingFixture.sign({ sub: 'user-1' })
+    const refreshedIdToken = await signingFixture.sign({ sub: 'user-1' })
+    const refreshHarness = new HandlerHarness({
+      runtimeConfig: createRuntimeConfig(testCase.overrides),
+    })
+    await seedSession(refreshHarness, `refresh-${testCase.name}`)
+    interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () =>
+          Response.json({
+            access_token: refreshedAccessToken,
+            id_token: refreshedIdToken,
+            refresh_token: 'rotated-refresh-token',
+            token_type: 'Bearer',
+            expires_in: '3600',
+          }),
+      },
+    ])
+    const refreshRequest = refreshHarness.createEvent({ path: '/api/_auth/session/refresh' })
+    const refreshedSession = await refreshUserSession(refreshRequest.event)
+
+    expectTokenExposure(refreshedSession, {
+      ...(testCase.exposeAccessToken && { accessToken: refreshedAccessToken }),
+      ...(testCase.exposeIdToken && { idToken: refreshedIdToken }),
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- verify explicit token exposure values on initial and refreshed sessions
- prove provider-level `true` and `false` override library and Keycloak preset defaults
- prove omitted values inherit current access-token and ID-token defaults
- ensure disabled tokens are absent from returned session payloads
- add token exposure override behavior to Unreleased changelog

## Context

Central runtime provider resolution from #168 already removed both stale `||` fallback paths in session handling. This PR locks that behavior with a complete true, false, and omitted matrix instead of adding duplicate resolution logic.

## Validation

- `pnpm fmt:check` - passed
- `pnpm lint` - passed with 24 existing Vitest mock-typing warnings
- `pnpm typecheck` - passed
- `pnpm test:unit` - 141/141 passed
- `pnpm test:functional` - 88/88 passed
- focused token exposure coverage - 3/3 passed
- `pnpm prepack` - passed
- regression proof against previous `||` semantics - explicit false case failed as expected
- independent xhigh security review - no findings

Closes #181
Tracks #179