### PR TITLE
fix(sso): respect Nuxt app base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **config:** Resolve provider environment overrides before deriving runtime endpoints
 - **session:** Respect explicit token exposure overrides
 - **auth:** Preserve valid sessions after stale callbacks
+- **sso:** Respect Nuxt app baseURL for single sign-out connections
 
 ## v1.0.0-beta.11
 

--- a/src/runtime/plugins/sso.client.ts
+++ b/src/runtime/plugins/sso.client.ts
@@ -1,8 +1,9 @@
-import { defineNuxtPlugin, onNuxtReady, useOidcAuth } from '#imports'
+import { defineNuxtPlugin, onNuxtReady, useOidcAuth, useRuntimeConfig } from '#imports'
+import { withBase } from 'ufo'
 
 export default defineNuxtPlugin(() => {
   const { loggedIn, currentProvider, logout, refresh, user } = useOidcAuth()
-  const sseUrl = '/api/_auth/sso'
+  const sseUrl = withBase('/api/_auth/sso', useRuntimeConfig().app.baseURL || '/')
   let eventSource: EventSource | null = null
   let retryTimeout: number | null = null
   const retryDelay = 2000

--- a/src/runtime/plugins/sso.client.ts
+++ b/src/runtime/plugins/sso.client.ts
@@ -1,9 +1,9 @@
 import { defineNuxtPlugin, onNuxtReady, useOidcAuth, useRuntimeConfig } from '#imports'
-import { withBase } from 'ufo'
+import { joinURL } from 'ufo'
 
 export default defineNuxtPlugin(() => {
   const { loggedIn, currentProvider, logout, refresh, user } = useOidcAuth()
-  const sseUrl = withBase('/api/_auth/sso', useRuntimeConfig().app.baseURL || '/')
+  const sseUrl = joinURL(useRuntimeConfig().app.baseURL || '/', '/api/_auth/sso')
   let eventSource: EventSource | null = null
   let retryTimeout: number | null = null
   const retryDelay = 2000

--- a/test/functional/sso-base-url.test.ts
+++ b/test/functional/sso-base-url.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  baseURL: '/' as string | undefined,
+  urls: [] as string[],
+}))
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (plugin: () => void) => plugin,
+  onNuxtReady: (callback: () => void) => callback(),
+  useOidcAuth: () => ({
+    currentProvider: { value: 'oidc' },
+    loggedIn: { value: true },
+    logout: vi.fn<() => Promise<void>>(),
+    refresh: vi.fn<() => Promise<void>>(),
+    user: { value: { singleSignOut: true } },
+  }),
+  useRuntimeConfig: () => ({ app: { baseURL: mocks.baseURL } }),
+}))
+
+class EventSourceStub {
+  static readonly CLOSED = 2
+  readonly readyState = 1
+  onerror: (() => void) | null = null
+  onopen: (() => void) | null = null
+
+  constructor(url: string | URL) {
+    mocks.urls.push(String(url))
+  }
+
+  addEventListener(): void {}
+
+  close(): void {}
+}
+
+beforeEach(() => {
+  mocks.urls = []
+  vi.stubGlobal('EventSource', EventSourceStub)
+  vi.stubGlobal('window', {
+    addEventListener: vi.fn<(event: string, callback: () => void) => void>(),
+    setTimeout: vi.fn<(callback: () => void, delay: number) => number>(),
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('single sign-out base URL', () => {
+  it.each([
+    { baseURL: undefined, expected: '/api/_auth/sso' },
+    { baseURL: '/', expected: '/api/_auth/sso' },
+    { baseURL: '/prefix/', expected: '/prefix/api/_auth/sso' },
+    { baseURL: '/prefix', expected: '/prefix/api/_auth/sso' },
+  ])('connects to $expected for baseURL $baseURL', async ({ baseURL, expected }) => {
+    mocks.baseURL = baseURL
+    const plugin = (await import('../../src/runtime/plugins/sso.client')).default
+
+    if (typeof plugin !== 'function') throw new Error('Expected functional Nuxt plugin')
+    void plugin({} as never)
+
+    expect(mocks.urls).toEqual([expected])
+  })
+})

--- a/test/functional/sso-base-url.test.ts
+++ b/test/functional/sso-base-url.test.ts
@@ -52,6 +52,8 @@ describe('single sign-out base URL', () => {
     { baseURL: '/', expected: '/api/_auth/sso' },
     { baseURL: '/prefix/', expected: '/prefix/api/_auth/sso' },
     { baseURL: '/prefix', expected: '/prefix/api/_auth/sso' },
+    { baseURL: '/api/', expected: '/api/api/_auth/sso' },
+    { baseURL: '/api', expected: '/api/api/_auth/sso' },
   ])('connects to $expected for baseURL $baseURL', async ({ baseURL, expected }) => {
     mocks.baseURL = baseURL
     const plugin = (await import('../../src/runtime/plugins/sso.client')).default


### PR DESCRIPTION
## Summary

- resolve the single-sign-out EventSource URL against Nuxt `app.baseURL`
- preserve root, custom-prefix, and overlapping-prefix path segments
- cover URL construction offline without changing retry, logout, or disconnect behavior

## Verification

- `pnpm fmt:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 19 files, 249 tests
- `pnpm prepack`

Refs #182