### PR TITLE
fix(logout): preserve per-call redirect URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **session:** Respect explicit token exposure overrides
 - **auth:** Preserve valid sessions after stale callbacks
 - **sso:** Respect Nuxt app baseURL for single sign-out connections
+- **logout:** Preserve and encode per-call redirect URIs
 
 ## v1.0.0-beta.11
 

--- a/src/runtime/composables/oidcAuth.ts
+++ b/src/runtime/composables/oidcAuth.ts
@@ -9,7 +9,7 @@ import {
   useState,
 } from '#imports'
 import { appendResponseHeader } from 'h3'
-import { withBase } from 'ufo'
+import { withBase, withQuery } from 'ufo'
 
 export function useOidcAuth() {
   const sessionState = useState<UserSession>('nuxt-oidc-auth-session', undefined)
@@ -77,7 +77,10 @@ export function useOidcAuth() {
     logoutRedirectUri?: string,
   ): Promise<void> {
     const baseURL = useRuntimeConfig().app.baseURL || '/'
-    const logoutPath = `/auth${provider ? `/${provider}` : currentProvider.value ? `/${currentProvider.value}` : ''}/logout${logoutRedirectUri ? `?logout_redirect_uri=${logoutRedirectUri}` : ''}`
+    const logoutPath = withQuery(
+      `/auth${provider ? `/${provider}` : currentProvider.value ? `/${currentProvider.value}` : ''}/logout`,
+      { ...(logoutRedirectUri && { logoutRedirectUri }) },
+    )
     await navigateTo(withBase(logoutPath, baseURL), { external: true, redirectCode: 302 })
     if (sessionState.value) {
       sessionState.value = undefined as unknown as UserSession

--- a/src/runtime/server/handler/logout.get.ts
+++ b/src/runtime/server/handler/logout.get.ts
@@ -34,7 +34,10 @@ export function logoutEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
 
     if (config.logoutUrl) {
       const logoutParams = getQuery(event)
-      const logoutRedirectUri = logoutParams.logoutRedirectUri || config.logoutRedirectUri
+      const logoutRedirectUri =
+        logoutParams.logoutRedirectUri ||
+        logoutParams.logout_redirect_uri ||
+        config.logoutRedirectUri
 
       // Set logout_hint and id_token_hint dynamic parameters if specified. According to https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
       const additionalLogoutParameters: Record<string, string> = config.additionalLogoutParameters

--- a/test/functional/logout.test.ts
+++ b/test/functional/logout.test.ts
@@ -1,0 +1,79 @@
+import type { OidcProviderConfig } from '../../src/runtime/server/utils/provider'
+import { describe, expect, it } from 'vitest'
+import { HandlerHarness } from './handler-harness'
+
+const configuredRedirectUri = 'https://app.example.test/configured'
+const perCallRedirectUri = 'https://app.example.test/after?next=one&value=two#résumé path'
+
+const providerConfig = {
+  clientId: 'functional-client',
+  clientSecret: 'functional-secret',
+  authorizationUrl: 'https://identity.example.test/authorize',
+  tokenUrl: 'https://identity.example.test/token',
+  redirectUri: 'https://app.example.test/auth/oidc/callback',
+  logoutUrl: 'https://identity.example.test/logout',
+  logoutRedirectParameterName: 'post_logout_redirect_uri',
+  logoutRedirectUri: configuredRedirectUri,
+  requiredProperties: ['clientId', 'clientSecret', 'authorizationUrl', 'tokenUrl', 'redirectUri'],
+} satisfies Partial<OidcProviderConfig>
+
+async function invokeLogout(
+  query: Record<string, string> = {},
+  overrides: Partial<OidcProviderConfig> = {},
+) {
+  const harness = new HandlerHarness({
+    runtimeConfig: {
+      oidc: {
+        session: {},
+        providers: { oidc: { ...providerConfig, ...overrides } },
+      },
+    },
+  })
+  const logoutHandler = (await import('../../src/runtime/server/handler/logout.get')).default
+  const request = harness.createEvent({ path: '/auth/oidc/logout', query })
+
+  await logoutHandler(request.event)
+
+  expect(request.response.status).toBe(302)
+  expect(request.response.location).toBeDefined()
+  return new URL(request.response.location!)
+}
+
+describe('logout handler redirects', () => {
+  it.each(['logoutRedirectUri', 'logout_redirect_uri'])('accepts %s', async (parameter) => {
+    const logoutUrl = await invokeLogout({ [parameter]: perCallRedirectUri })
+
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(perCallRedirectUri)
+  })
+
+  it('prefers the canonical spelling when both are present', async () => {
+    const logoutUrl = await invokeLogout({
+      logoutRedirectUri: perCallRedirectUri,
+      logout_redirect_uri: 'https://app.example.test/legacy',
+    })
+
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(perCallRedirectUri)
+  })
+
+  it('falls back to the configured redirect', async () => {
+    const logoutUrl = await invokeLogout()
+
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(configuredRedirectUri)
+  })
+
+  it('keeps the configured provider parameter name', async () => {
+    const logoutUrl = await invokeLogout(
+      { logoutRedirectUri: perCallRedirectUri },
+      { logoutRedirectParameterName: 'returnTo' },
+    )
+
+    expect(logoutUrl.searchParams.get('returnTo')).toBe(perCallRedirectUri)
+    expect(logoutUrl.searchParams.has('post_logout_redirect_uri')).toBe(false)
+  })
+
+  it('omits the provider redirect parameter when no redirect is available', async () => {
+    const logoutUrl = await invokeLogout({}, { logoutRedirectUri: undefined })
+
+    expect(logoutUrl.toString()).toBe(`${providerConfig.logoutUrl}`)
+  })
+})

--- a/test/unit/oidc-auth.test.ts
+++ b/test/unit/oidc-auth.test.ts
@@ -1,0 +1,57 @@
+import type { UserSession } from '../../src/runtime/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  baseURL: '/',
+  navigateTo:
+    vi.fn<(path: string, options: { external: boolean; redirectCode: number }) => Promise<void>>(),
+  session: { value: undefined as UserSession | undefined },
+}))
+
+vi.mock('#imports', () => ({
+  computed: <T>(getter: () => T) => ({
+    get value(): T {
+      return getter()
+    },
+  }),
+  navigateTo: mocks.navigateTo,
+  useRequestEvent: vi.fn<() => undefined>(),
+  useRequestFetch: vi.fn<() => never>(),
+  useRuntimeConfig: () => ({ app: { baseURL: mocks.baseURL } }),
+  useState: () => mocks.session,
+}))
+
+beforeEach(() => {
+  mocks.baseURL = '/'
+  mocks.navigateTo.mockReset()
+  mocks.navigateTo.mockResolvedValue()
+  mocks.session.value = undefined
+})
+
+describe('useOidcAuth logout', () => {
+  it('emits the canonical encoded redirect query', async () => {
+    const { useOidcAuth } = await import('../../src/runtime/composables/oidcAuth')
+    const redirectUri = 'https://app.example.test/after?next=one&value=two#résumé path'
+
+    await useOidcAuth().logout('oidc', redirectUri)
+
+    expect(mocks.navigateTo).toHaveBeenCalledOnce()
+    const [path, options] = mocks.navigateTo.mock.calls[0]!
+    const logoutUrl = new URL(path, 'https://app.example.test')
+    expect(logoutUrl.pathname).toBe('/auth/oidc/logout')
+    expect(logoutUrl.searchParams.get('logoutRedirectUri')).toBe(redirectUri)
+    expect(logoutUrl.searchParams.has('logout_redirect_uri')).toBe(false)
+    expect(options).toEqual({ external: true, redirectCode: 302 })
+  })
+
+  it('keeps logout navigation unchanged without a redirect', async () => {
+    const { useOidcAuth } = await import('../../src/runtime/composables/oidcAuth')
+
+    await useOidcAuth().logout('oidc')
+
+    expect(mocks.navigateTo).toHaveBeenCalledWith('/auth/oidc/logout', {
+      external: true,
+      redirectCode: 302,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- emit canonical, encoded `logoutRedirectUri` from composable
- accept camelCase and legacy snake_case input in handler, with canonical precedence
- keep configured fallback and provider-specific logout parameter behavior

## Checks

- format, lint, typecheck, focused flows, and full suite
- module and client production build

Refs #133