### PR TITLE
test: add integrated release compatibility coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 
 ## Unreleased
 
-### 🩹 Fixes
+### 🛡️ Security
 
 - **auth:** Prevent client overrides of reserved OAuth/OIDC authorization parameters
 - **auth:** Preserve dynamic callback redirects and reject unsafe local redirect paths
 - **auth:** Add strict callback token validation and migration guidance
-- **auth:** Preserve token request values during transport encoding
 - **session:** Replace token-derived data on login and refresh
 - **auth:** Validate strict-mode refresh token responses
+
+### 🩹 Fixes
+
+- **auth:** Preserve token request values during transport encoding
 - **auth0:** Document opaque access-token configuration
 - **config:** Allow public PKCE clients to omit client secrets
 - **config:** Resolve provider environment overrides before deriving runtime endpoints
@@ -18,6 +21,11 @@
 - **auth:** Preserve valid sessions after stale callbacks
 - **sso:** Respect Nuxt app baseURL for single sign-out connections
 - **logout:** Preserve and encode per-call redirect URIs
+
+### ✅ Release checks
+
+- Offline unit, handler, and browser coverage exercises integrated session, callback, logout, runtime-configuration, and custom-baseURL behavior.
+- Keycloak and Auth0 browser flows require provider credentials and were skipped locally; no live provider verification was available.
 
 ## v1.0.0-beta.11
 

--- a/client/components/AuthState.vue
+++ b/client/components/AuthState.vue
@@ -16,7 +16,7 @@ defineProps<{
     <NCodeBlock
       v-if="Object.keys(oidcState).length > 0"
       class="overflow-x-scroll"
-      lang="JSON"
+      lang="json"
       :code="JSON.stringify(oidcState, null, '\t')"
     />
     <NTip

--- a/client/components/DevMode.vue
+++ b/client/components/DevMode.vue
@@ -47,7 +47,7 @@ defineProps<{
       <NCodeBlock
         v-if="oidcRuntimeConfig?.devMode && Object.keys(oidcRuntimeConfig.devMode).length > 0"
         class="overflow-x-scroll"
-        lang="JSON"
+        lang="json"
         :code="JSON.stringify(oidcRuntimeConfig.devMode, null, '\t')"
       />
       <p>

--- a/client/components/ProviderConfigs.vue
+++ b/client/components/ProviderConfigs.vue
@@ -62,7 +62,7 @@ const configJson = computed(() => {
     <NCodeBlock
       v-if="model"
       class="overflow-x-auto"
-      lang="JSON"
+      lang="json"
       :code="configJson"
     />
   </NSectionBlock>

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -1,24 +1,50 @@
 <script setup lang="ts">
-import type { NuxtDevtoolsIframeClient } from '@nuxt/devtools-kit'
+import type { NuxtDevtoolsIframeClient } from '@nuxt/devtools-kit/types'
 import { onDevtoolsClientConnected } from '@nuxt/devtools-kit/iframe-client'
 import { computed, ref } from 'vue'
 
 export interface OidcConfig {
-  providers: Record<string, undefined>
-  devMode: Record<'enabled', boolean>
-  session: Record<'expirationCheck', boolean>
+  providers: Record<string, unknown>
+  devMode: Record<string, unknown>
+}
+
+type OidcSecrets = Record<'tokenKey' | 'sessionSecret' | 'authSessionSecret', string>
+interface OidcDevtoolsServerFunctions {
+  getNuxtOidcAuthSecrets: (token: string) => Promise<OidcSecrets>
+}
+
+function emptyOidcConfig(): OidcConfig {
+  return { providers: {}, devMode: {} }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getOidcConfig(config: unknown): OidcConfig | undefined {
+  if (!isRecord(config)) return
+  const oidc = config.oidc
+  if (!isRecord(oidc)) return
+
+  const providers = isRecord(oidc.providers) ? oidc.providers : {}
+  const devMode = isRecord(oidc.devMode) ? oidc.devMode : {}
+
+  return { providers, devMode }
 }
 
 const showLoginDropdown = ref(false)
 const showLogoutDropdown = ref(false)
-const devtoolsClient: NuxtDevtoolsIframeClient | null = ref(null)
+const devtoolsClient = ref<NuxtDevtoolsIframeClient>()
 const devAuthToken = ref<string | null>(localStorage.getItem('__nuxt_dev_token__'))
-const oidcRuntimeConfig = ref()
+const oidcRuntimeConfig = ref<OidcConfig>(emptyOidcConfig())
 const oidcConfig = ref<OidcConfig>()
-const selectedProvider = ref('')
 const oidcState = ref({})
-const clientWindow = computed(() => devtoolsClient.value.host?.app)
-const oidcSecrets = ref({})
+const clientWindow = computed(() => devtoolsClient.value?.host.app)
+const oidcSecrets = ref<OidcSecrets>({
+  tokenKey: '',
+  sessionSecret: '',
+  authSessionSecret: '',
+})
 const isDevAuthed = ref(false)
 const registeredProviders = computed(() => oidcConfig.value?.providers ? oidcConfig.value?.providers : {})
 
@@ -26,19 +52,29 @@ onDevtoolsClientConnected(async (client: NuxtDevtoolsIframeClient) => {
   // Getting devtools client
   devtoolsClient.value = client
   // Settings refs
-  isDevAuthed.value = await devtoolsClient.value.devtools.rpc.verifyAuthToken(devAuthToken.value)
-  oidcRuntimeConfig.value = isDevAuthed.value ? (await devtoolsClient.value.devtools.rpc.getServerRuntimeConfig()).oidc : {}
-  oidcConfig.value = isDevAuthed.value ? (await devtoolsClient.value.devtools.rpc.getServerConfig()).oidc : {}
+  isDevAuthed.value = devAuthToken.value !== null && await devtoolsClient.value.devtools.rpc.verifyAuthToken(devAuthToken.value)
+  oidcRuntimeConfig.value = isDevAuthed.value
+    ? getOidcConfig(await devtoolsClient.value.devtools.rpc.getServerRuntimeConfig()) || emptyOidcConfig()
+    : emptyOidcConfig()
+  oidcConfig.value = isDevAuthed.value
+    ? getOidcConfig(await devtoolsClient.value.devtools.rpc.getServerConfig())
+    : undefined
   oidcState.value = devtoolsClient.value.host.nuxt.payload.state['$snuxt-oidc-auth-session'] || {}
-  oidcSecrets.value = isDevAuthed.value ? await devtoolsClient.value.devtools.extendClientRpc('nuxt-oidc-auth-rpc').getNuxtOidcAuthSecrets(devAuthToken.value || '') : {}
+  const oidcRpc = devtoolsClient.value.devtools.extendClientRpc<
+    OidcDevtoolsServerFunctions,
+    Record<string, never>
+  >('nuxt-oidc-auth-rpc', {})
+  oidcSecrets.value = isDevAuthed.value
+    ? await oidcRpc.getNuxtOidcAuthSecrets(devAuthToken.value || '')
+    : { tokenKey: '', sessionSecret: '', authSessionSecret: '' }
 })
 
 async function login(provider?: string) {
-  clientWindow.value.navigate(`/auth${provider ? `/${provider}` : ''}/login`, true)
+  clientWindow.value?.navigate(`/auth${provider ? `/${provider}` : ''}/login`, true)
 }
 
 async function logout(provider?: string) {
-  clientWindow.value.navigate(`/auth${provider ? `/${provider}` : ''}/logout`, true)
+  clientWindow.value?.navigate(`/auth${provider ? `/${provider}` : ''}/logout`, true)
 }
 </script>
 
@@ -82,7 +118,7 @@ async function logout(provider?: string) {
               :border="false"
               @click="login(provider)"
             >
-              {{ provider[0].toUpperCase() + provider.slice(1) }}
+              {{ provider.charAt(0).toUpperCase() + provider.slice(1) }}
             </button>
           </div>
         </NDropdown>
@@ -114,7 +150,7 @@ async function logout(provider?: string) {
               :border="false"
               @click="logout(provider)"
             >
-              {{ provider[0].toUpperCase() + provider.slice(1) }}
+              {{ provider.charAt(0).toUpperCase() + provider.slice(1) }}
             </button>
           </div>
         </NDropdown>

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -57,8 +57,8 @@ onDevtoolsClientConnected(async (client: NuxtDevtoolsIframeClient) => {
     ? getOidcConfig(await devtoolsClient.value.devtools.rpc.getServerRuntimeConfig()) || emptyOidcConfig()
     : emptyOidcConfig()
   oidcConfig.value = isDevAuthed.value
-    ? getOidcConfig(await devtoolsClient.value.devtools.rpc.getServerConfig())
-    : undefined
+    ? getOidcConfig(await devtoolsClient.value.devtools.rpc.getServerConfig()) || emptyOidcConfig()
+    : emptyOidcConfig()
   oidcState.value = devtoolsClient.value.host.nuxt.payload.state['$snuxt-oidc-auth-session'] || {}
   const oidcRpc = devtoolsClient.value.devtools.extendClientRpc<
     OidcDevtoolsServerFunctions,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "typecheck": "nuxt typecheck",
+    "client:typecheck": "nuxi typecheck client",
     "test": "vitest run --config test/vitest.config.ts --root .",
     "test:watch": "vitest watch --config test/vitest.config.ts --root .",
     "test:unit": "vitest run --config test/vitest.config.ts --root . test/unit/",

--- a/test/e2e/flows/base-url-custom.test.ts
+++ b/test/e2e/flows/base-url-custom.test.ts
@@ -95,4 +95,17 @@ test.describe('Issue #60: BaseURL Support - Custom Prefix /prefix/', () => {
       response.status === 302 && response.headers.get('location')?.includes('authorize')
     expect(isDirectlyAccessible).toBe(false)
   })
+
+  test('single sign-out connects through the configured prefix', async ({ page }) => {
+    const origin = getServerOrigin()
+    await page.context().request.post(`${origin}/prefix/api/test/session-sso`)
+
+    const ssoRequest = page.waitForRequest((request) => {
+      return new URL(request.url()).pathname === '/prefix/api/_auth/sso'
+    })
+    await page.goto(`${origin}/prefix/`)
+
+    await ssoRequest
+    await expect(page.locator('div[name="singleSignOut"]')).toHaveText('true')
+  })
 })

--- a/test/e2e/flows/dev-mode-metadata.test.ts
+++ b/test/e2e/flows/dev-mode-metadata.test.ts
@@ -9,6 +9,7 @@ test.use({
     dev: true,
   },
 })
+test.describe.configure({ mode: 'serial' })
 
 test.describe('Dev Mode Discovery Endpoint', () => {
   test('exposes discovery endpoint', async () => {

--- a/test/e2e/flows/integrated-session.test.ts
+++ b/test/e2e/flows/integrated-session.test.ts
@@ -10,6 +10,9 @@ let userInfoAvailable = true
 let lastLogoutRedirect: string | null = null
 let blockedTokenRequest: Promise<void> | undefined
 let tokenRequestStarted: (() => void) | undefined
+const appOrigin = 'http://127.0.0.1:31840'
+const logoutRedirectTarget = `${appOrigin}/excluded?next=one&value=two#resume path`
+const expectedLogoutRedirect = new URL(logoutRedirectTarget).toString()
 
 function jwt(payload: Record<string, unknown>): string {
   const encodedHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString(
@@ -84,7 +87,7 @@ const provider = createServer(async (request, response) => {
 
   if (requestUrl.pathname === '/logout') {
     lastLogoutRedirect = requestUrl.searchParams.get('post_logout_redirect_uri')
-    response.writeHead(302, { location: lastLogoutRedirect || '/' }).end()
+    response.writeHead(302, { location: expectedLogoutRedirect }).end()
     return
   }
 
@@ -121,8 +124,8 @@ test.use({
             userInfoUrl: `${providerOrigin}/userinfo`,
             logoutUrl: `${providerOrigin}/logout`,
             logoutRedirectParameterName: 'post_logout_redirect_uri',
-            redirectUri: 'http://127.0.0.1:31840/auth/oidc/callback',
-            allowedCallbackRedirectUrls: ['http://127.0.0.1:31840'],
+            redirectUri: `${appOrigin}/auth/oidc/callback`,
+            allowedCallbackRedirectUrls: [appOrigin],
             optionalClaims: ['resource_access'],
             userNameClaim: 'preferred_username',
             tokenRequestType: 'form-urlencoded',
@@ -196,11 +199,10 @@ test('preserves current session data across integrated browser flows', async ({ 
   await expect(page.locator('div[name="userName"]')).toHaveText('second-user')
   await expect(page.locator('div[name="userInfo"]')).toHaveText('')
 
-  const redirectTarget = `${url('/excluded')}?next=one&value=two#resume path`
   await page.goto(
-    `${url('/auth/oidc/logout')}?logoutRedirectUri=${encodeURIComponent(redirectTarget)}`,
+    `${url('/auth/oidc/logout')}?logoutRedirectUri=${encodeURIComponent(logoutRedirectTarget)}`,
   )
 
-  expect(lastLogoutRedirect).toBe(redirectTarget)
-  expect(page.url()).toBe(redirectTarget.replace(' ', '%20'))
+  expect(lastLogoutRedirect).toBe(logoutRedirectTarget)
+  expect(page.url()).toBe(expectedLogoutRedirect)
 })

--- a/test/e2e/flows/integrated-session.test.ts
+++ b/test/e2e/flows/integrated-session.test.ts
@@ -1,0 +1,206 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { fileURLToPath } from 'node:url'
+import { url } from '@nuxt/test-utils/e2e'
+import { expect, test } from '@nuxt/test-utils/playwright'
+import type { Page } from '@playwright/test'
+
+let tokenRequestCount = 0
+let userInfoAvailable = true
+let lastLogoutRedirect: string | null = null
+let blockedTokenRequest: Promise<void> | undefined
+let tokenRequestStarted: (() => void) | undefined
+
+function jwt(payload: Record<string, unknown>): string {
+  const encodedHeader = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString(
+    'base64url',
+  )
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${encodedHeader}.${encodedPayload}.signature`
+}
+
+function tokenResponse(requestIndex: number) {
+  const now = Math.trunc(Date.now() / 1000)
+  const identity = requestIndex >= 3 ? 'second-user' : 'first-user'
+  const role = requestIndex === 1 ? 'admin-role' : 'user-role'
+
+  return {
+    access_token: jwt({ sub: identity, preferred_username: identity, iat: now, exp: now + 3600 }),
+    id_token: jwt({
+      sub: identity,
+      iat: now,
+      exp: now + 3600,
+      resource_access: { playground: { roles: [role] } },
+    }),
+    refresh_token: `refresh-token-${requestIndex}`,
+    token_type: 'Bearer',
+    expires_in: 3600,
+  }
+}
+
+const provider = createServer(async (request, response) => {
+  const requestUrl = new URL(request.url || '/', `http://${request.headers.host}`)
+
+  if (requestUrl.pathname === '/authorize') {
+    const redirectUri = requestUrl.searchParams.get('redirect_uri')
+    const state = requestUrl.searchParams.get('state')
+    if (!redirectUri || !state) {
+      response.writeHead(400).end()
+      return
+    }
+
+    const callback = new URL(redirectUri)
+    callback.searchParams.set('code', `code-${tokenRequestCount + 1}`)
+    callback.searchParams.set('state', state)
+    response.writeHead(302, { location: callback.toString() }).end()
+    return
+  }
+
+  if (requestUrl.pathname === '/token') {
+    tokenRequestCount += 1
+    if (blockedTokenRequest) {
+      const release = blockedTokenRequest
+      blockedTokenRequest = undefined
+      tokenRequestStarted?.()
+      await release
+    }
+    userInfoAvailable = tokenRequestCount < 3
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.end(JSON.stringify(tokenResponse(tokenRequestCount)))
+    return
+  }
+
+  if (requestUrl.pathname === '/userinfo') {
+    if (!userInfoAvailable) {
+      response.writeHead(404, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ error: 'not_found' }))
+      return
+    }
+
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.end(JSON.stringify({ displayName: 'First User' }))
+    return
+  }
+
+  if (requestUrl.pathname === '/logout') {
+    lastLogoutRedirect = requestUrl.searchParams.get('post_logout_redirect_uri')
+    response.writeHead(302, { location: lastLogoutRedirect || '/' }).end()
+    return
+  }
+
+  response.writeHead(404).end()
+})
+
+provider.listen(0, '127.0.0.1')
+await once(provider, 'listening')
+const providerAddress = provider.address()
+if (!providerAddress || typeof providerAddress === 'string') {
+  throw new Error('Mock provider did not bind a TCP port')
+}
+const providerOrigin = `http://127.0.0.1:${providerAddress.port}`
+
+test.use({
+  nuxt: {
+    rootDir: fileURLToPath(new URL('../../fixtures/oidcApp', import.meta.url)),
+    build: true,
+    port: 31840,
+    env: {
+      NUXT_OIDC_AUTH_SESSION_SECRET: 'test-auth-session-secret-at-least-48-characters-long',
+      NUXT_OIDC_SESSION_SECRET: 'test-user-session-secret-at-least-48-characters-long',
+      NUXT_OIDC_TOKEN_KEY: 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    },
+    nuxtConfig: {
+      oidc: {
+        defaultProvider: 'oidc',
+        providers: {
+          oidc: {
+            clientId: 'browser-client',
+            clientSecret: 'browser-secret',
+            authorizationUrl: `${providerOrigin}/authorize`,
+            tokenUrl: `${providerOrigin}/token`,
+            userInfoUrl: `${providerOrigin}/userinfo`,
+            logoutUrl: `${providerOrigin}/logout`,
+            logoutRedirectParameterName: 'post_logout_redirect_uri',
+            redirectUri: 'http://127.0.0.1:31840/auth/oidc/callback',
+            allowedCallbackRedirectUrls: ['http://127.0.0.1:31840'],
+            optionalClaims: ['resource_access'],
+            userNameClaim: 'preferred_username',
+            tokenRequestType: 'form-urlencoded',
+            pkce: false,
+            nonce: false,
+            validateAccessToken: false,
+            validateIdToken: false,
+            sessionConfiguration: {
+              singleSignOut: false,
+              expirationCheck: false,
+            },
+          },
+        },
+        middleware: {
+          globalMiddlewareEnabled: false,
+          customLoginPage: true,
+        },
+      },
+    },
+  },
+})
+
+test.afterAll(async () => {
+  provider.close()
+  await once(provider, 'close')
+})
+
+test('preserves current session data across integrated browser flows', async ({ page, goto }) => {
+  tokenRequestCount = 0
+  userInfoAvailable = true
+  lastLogoutRedirect = null
+  blockedTokenRequest = undefined
+  tokenRequestStarted = undefined
+
+  await goto(url('/auth/login'))
+  await page.click('button[name="oidc"]')
+  await page.waitForURL(url('/'))
+
+  await expect(page.locator('div[name="userName"]')).toHaveText('first-user')
+  await expect(page.locator('div[name="claims"]')).toContainText('admin-role')
+  await expect(page.locator('div[name="userInfo"]')).toContainText('First User')
+
+  await page.context().request.post(url('/api/test/session-stale'))
+  await page.click('button[name="refresh"]')
+  await expect(page.locator('div[name="claims"]')).toContainText('user-role')
+  await expect(page.locator('div[name="claims"]')).not.toContainText('admin-role')
+
+  await goto(url('/auth/login'))
+  let releaseTokenRequest: () => void = () => {}
+  const tokenRequestReached = new Promise<void>((resolve) => {
+    tokenRequestStarted = resolve
+  })
+  blockedTokenRequest = new Promise<void>((resolve) => {
+    releaseTokenRequest = resolve
+  })
+
+  await page.click('button[name="oidc"]', { noWaitAfter: true })
+  await tokenRequestReached
+
+  let staleTab: Page | undefined
+  try {
+    staleTab = await page.context().newPage()
+    await staleTab.goto(url('/auth/oidc/callback'))
+    await expect(staleTab.locator('div[name="loggedIn"]')).toHaveText('true')
+  } finally {
+    releaseTokenRequest()
+    await staleTab?.close()
+  }
+  await page.waitForURL(url('/'))
+
+  await expect(page.locator('div[name="userName"]')).toHaveText('second-user')
+  await expect(page.locator('div[name="userInfo"]')).toHaveText('')
+
+  const redirectTarget = `${url('/excluded')}?next=one&value=two#resume path`
+  await page.goto(
+    `${url('/auth/oidc/logout')}?logoutRedirectUri=${encodeURIComponent(redirectTarget)}`,
+  )
+
+  expect(lastLogoutRedirect).toBe(redirectTarget)
+  expect(page.url()).toBe(redirectTarget.replace(' ', '%20'))
+})

--- a/test/fixtures/oidcApp/pages/index.vue
+++ b/test/fixtures/oidcApp/pages/index.vue
@@ -20,6 +20,15 @@ const { refresh, fetch, logout, clear, user, currentProvider, loggedIn } = useOi
   <div name="singleSignOut">
     {{ user?.singleSignOut }}
   </div>
+  <div name="userName">
+    {{ user?.userName }}
+  </div>
+  <div name="claims">
+    {{ JSON.stringify(user?.claims) }}
+  </div>
+  <div name="userInfo">
+    {{ JSON.stringify(user?.userInfo) }}
+  </div>
   <div name="loggedIn">
     {{ loggedIn }}
   </div>

--- a/test/fixtures/oidcApp/server/api/test/session-sso.post.ts
+++ b/test/fixtures/oidcApp/server/api/test/session-sso.post.ts
@@ -1,0 +1,14 @@
+import { defineEventHandler } from 'h3'
+import { setUserSession } from '../../../../../../src/runtime/server/utils/session'
+
+export default defineEventHandler(async (event) => {
+  const now = Math.trunc(Date.now() / 1000)
+  return await setUserSession(event, {
+    provider: 'oidc',
+    canRefresh: false,
+    expireAt: now + 3600,
+    loggedInAt: now,
+    updatedAt: now,
+    singleSignOut: true,
+  })
+})

--- a/test/fixtures/oidcApp/server/api/test/session-stale.post.ts
+++ b/test/fixtures/oidcApp/server/api/test/session-stale.post.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+import { getUserSession, setUserSession } from '../../../../../../src/runtime/server/utils/session'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+  return await setUserSession(event, { ...session, updatedAt: 1 })
+})


### PR DESCRIPTION
## Summary

This adds integrated browser coverage for session replacement, overlapping stale callbacks, logout redirects, runtime provider configuration, and single sign-out under a custom base URL. It also makes client typechecking explicit and updates DevTools client code for current Nuxt DevTools types.

Dev-mode metadata tests now run serially because they share one development server and session/key state.

## Release boundary

Local format, lint, root/client typechecks, unit, functional, browser, and package-build checks pass. Keycloak and Auth0 browser flows need provider credentials and remain skipped; no live provider check was available, so this does not close #184.

Tracks #184.