### PR TITLE
test: include Zitadel public client in provider CI

### DIFF
--- a/secretspec.toml
+++ b/secretspec.toml
@@ -31,5 +31,4 @@ NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_SECRET = { description = "Microsoft client 
 NUXT_OIDC_PROVIDERS_PAYPAL_CLIENT_ID = { description = "PayPal client ID", required = false }
 NUXT_OIDC_PROVIDERS_PAYPAL_CLIENT_SECRET = { description = "PayPal client secret", required = false }
 NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_ID = { description = "Zitadel client ID", required = false }
-NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_SECRET = { description = "Zitadel client secret", required = false }
 NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL = { description = "Zitadel tenant base URL", required = false }

--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -98,7 +98,6 @@ export const automatedProviderOptions = {
     authenticationScheme: 'none',
     baseUrl: process.env.NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL || '',
     clientId: process.env.NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_ID || '',
-    clientSecret: process.env.NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_SECRET || '',
     logoutRedirectUri: appOrigin,
     redirectUri: callback('zitadel'),
   },
@@ -262,7 +261,6 @@ export const providerConfigs: readonly TestProviderConfig[] = [
     name: 'zitadel',
     requiredEnvVars: [
       'NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_ID',
-      'NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_SECRET',
       'NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL',
     ],
     mode: 'online',
@@ -272,6 +270,13 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       refresh: true,
       singleSignOut: false,
       logoutRedirect: true,
+    },
+    loginPage: {
+      open: async (page, loginUrl) => {
+        await page.goto(loginUrl)
+        await page.waitForURL(/zitadel/)
+      },
+      selector: 'input',
     },
     config: automatedProviderOptions.zitadel,
   },

--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -1,9 +1,11 @@
 import type { ProviderConfigs } from '../../src/runtime/types'
 import type { TestProviderConfig } from '../setup/types'
+import { withHttps } from 'ufo'
 
 const appOrigin = process.env.NUXT_OIDC_TEST_APP_ORIGIN || 'http://localhost:31840'
 const callback = (provider: string) => `${appOrigin}/auth/${provider}/callback`
 const entraTenantId = process.env.NUXT_OIDC_PROVIDERS_ENTRA_TENANT_ID || ''
+const zitadelBaseUrl = process.env.NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL || ''
 
 export const automatedProviderOptions = {
   apple: {
@@ -96,7 +98,7 @@ export const automatedProviderOptions = {
   zitadel: {
     allowedCallbackRedirectUrls: [appOrigin],
     authenticationScheme: 'none',
-    baseUrl: process.env.NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL || '',
+    baseUrl: zitadelBaseUrl,
     clientId: process.env.NUXT_OIDC_PROVIDERS_ZITADEL_CLIENT_ID || '',
     logoutRedirectUri: appOrigin,
     redirectUri: callback('zitadel'),
@@ -274,9 +276,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
     loginPage: {
       open: async (page, loginUrl) => {
         await page.goto(loginUrl)
-        await page.waitForURL(/zitadel/)
+        const zitadelOrigin = new URL(withHttps(zitadelBaseUrl)).origin
+        await page.waitForURL((url) => url.origin === zitadelOrigin)
       },
-      selector: 'input',
+      selector: 'input[name="loginName"]',
     },
     config: automatedProviderOptions.zitadel,
   },


### PR DESCRIPTION
## Summary\n\n- stop requiring a client secret for the Zitadel PKCE public-client configuration\n- remove the unused SecretSpec entry\n- follow the authorization redirect and assert the hosted Zitadel login page loads\n\nThe SecretSpec-backed provider suite now includes Zitadel using only its client ID and base URL.