### PR TITLE
test: include Entra External ID in provider CI

### DIFF
--- a/secretspec.toml
+++ b/secretspec.toml
@@ -20,7 +20,9 @@ NUXT_OIDC_PROVIDERS_COGNITO_CLIENT_SECRET = { description = "AWS Cognito client 
 NUXT_OIDC_PROVIDERS_COGNITO_BASE_URL = { description = "AWS Cognito user-pool base URL", required = false }
 NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_ID = { description = "Microsoft Entra client ID", required = false }
 NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_SECRET = { description = "Microsoft Entra client secret", required = false }
-NUXT_OIDC_PROVIDERS_ENTRA_TENANT_ID = { description = "Microsoft Entra tenant ID", required = false }
+NUXT_OIDC_PROVIDERS_ENTRA_AUTHORIZATION_URL = { description = "Microsoft Entra authorization URL", required = false }
+NUXT_OIDC_PROVIDERS_ENTRA_TOKEN_URL = { description = "Microsoft Entra token URL", required = false }
+NUXT_OIDC_PROVIDERS_ENTRA_LOGOUT_URL = { description = "Microsoft Entra logout URL", required = false }
 NUXT_OIDC_PROVIDERS_GITHUB_CLIENT_ID = { description = "GitHub OAuth client ID", required = false }
 NUXT_OIDC_PROVIDERS_GITHUB_CLIENT_SECRET = { description = "GitHub OAuth client secret", required = false }
 NUXT_OIDC_PROVIDERS_LOGTO_CLIENT_ID = { description = "Logto client ID", required = false }

--- a/test/e2e/providers/providers.test.ts
+++ b/test/e2e/providers/providers.test.ts
@@ -53,6 +53,29 @@ for (const provider of providerConfigs) {
       })
     }
 
+    const logoutRedirect = provider.capabilities.logoutRedirect
+    if (logoutRedirect) {
+      test('initiates provider logout with configured redirect', async ({ request }) => {
+        test.skip(!isProviderConfigured(provider.name), `${provider.name} not configured`)
+
+        const sessionResponse = await request.post(`${appOrigin}/api/test/session-sso`)
+        expect(sessionResponse.ok()).toBe(true)
+
+        const response = await request.get(`${appOrigin}/auth/${provider.name}/logout`, {
+          maxRedirects: 0,
+        })
+        const location = response.headers().location
+
+        expect(response.status()).toBe(302)
+        expect(location).toBeTruthy()
+        if (!location) throw new Error(`Missing ${provider.name} logout redirect`)
+
+        const logoutUrl = new URL(location)
+        expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toMatch(logoutRedirect.urlPattern)
+        expect(logoutUrl.searchParams.get(logoutRedirect.parameterName)).toBe(appOrigin)
+      })
+    }
+
     if (provider.capabilities.fullLogin) {
       test('completes login and refreshes session', async ({ page }) => {
         await page.goto(`${appOrigin}/auth/${provider.name}/login`)

--- a/test/e2e/providers/providers.test.ts
+++ b/test/e2e/providers/providers.test.ts
@@ -71,7 +71,7 @@ for (const provider of providerConfigs) {
         if (!location) throw new Error(`Missing ${provider.name} logout redirect`)
 
         const logoutUrl = new URL(location)
-        expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toMatch(logoutRedirect.urlPattern)
+        expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toBe(logoutRedirect.url)
         expect(logoutUrl.searchParams.get(logoutRedirect.parameterName)).toBe(appOrigin)
       })
     }

--- a/test/e2e/providers/providers.test.ts
+++ b/test/e2e/providers/providers.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@nuxt/test-utils/playwright'
 import { providerConfigs } from '../../fixtures/providers'
 import { isProviderConfigured } from '../../setup/env-validator'
 
-const appOrigin = 'http://localhost:31840'
+const appOrigin = process.env.NUXT_OIDC_TEST_APP_ORIGIN || 'http://localhost:31840'
 
 for (const provider of providerConfigs) {
   test.describe(provider.name, () => {
@@ -70,9 +70,15 @@ for (const provider of providerConfigs) {
         expect(location).toBeTruthy()
         if (!location) throw new Error(`Missing ${provider.name} logout redirect`)
 
+        const configuredLogoutRedirect = provider.config.logoutRedirectUri
+        if (!configuredLogoutRedirect)
+          throw new Error(`Missing ${provider.name} logout redirect configuration`)
+
         const logoutUrl = new URL(location)
         expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toBe(logoutRedirect.url)
-        expect(logoutUrl.searchParams.get(logoutRedirect.parameterName)).toBe(appOrigin)
+        expect(logoutUrl.searchParams.get(logoutRedirect.parameterName)).toBe(
+          configuredLogoutRedirect,
+        )
       })
     }
 

--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -1,11 +1,19 @@
 import type { ProviderConfigs } from '../../src/runtime/types'
 import type { TestProviderConfig } from '../setup/types'
-import { withHttps } from 'ufo'
+import { joinURL, withHttps } from 'ufo'
 
 const appOrigin = process.env.NUXT_OIDC_TEST_APP_ORIGIN || 'http://localhost:31840'
 const callback = (provider: string) => `${appOrigin}/auth/${provider}/callback`
 const entraAuthorizationUrl = process.env.NUXT_OIDC_PROVIDERS_ENTRA_AUTHORIZATION_URL || ''
 const zitadelBaseUrl = process.env.NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL || ''
+const microsoftLogoutUrl = 'https://login.microsoftonline.com/common/oauth2/v2.0/logout'
+const originAndPath = (url: string) => {
+  if (!url) return ''
+  const parsedUrl = new URL(url)
+  return `${parsedUrl.origin}${parsedUrl.pathname}`
+}
+const providerEndpoint = (baseUrl: string, path: string) =>
+  baseUrl ? originAndPath(joinURL(withHttps(baseUrl), path)) : ''
 
 export const automatedProviderOptions = {
   apple: {
@@ -60,7 +68,7 @@ export const automatedProviderOptions = {
     clientId: process.env.NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_ID || '',
     clientSecret: process.env.NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_SECRET || '',
     logoutRedirectUri: appOrigin,
-    logoutUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout',
+    logoutUrl: microsoftLogoutUrl,
     redirectUri: callback('microsoft'),
   },
   oidc: {
@@ -178,7 +186,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       singleSignOut: false,
       logoutRedirect: {
         parameterName: 'logout_uri',
-        urlPattern: /\/logout$/,
+        url: providerEndpoint(process.env.NUXT_OIDC_PROVIDERS_COGNITO_BASE_URL || '', 'logout'),
       },
     },
     config: automatedProviderOptions.cognito,
@@ -201,8 +209,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       singleSignOut: false,
       logoutRedirect: {
         parameterName: 'post_logout_redirect_uri',
-        urlPattern:
-          /^https:\/\/(?:login\.microsoftonline\.com|[^/]+\.ciamlogin\.com)\/.+\/oauth2\/v2\.0\/logout$/,
+        url: originAndPath(process.env.NUXT_OIDC_PROVIDERS_ENTRA_LOGOUT_URL || ''),
       },
     },
     loginPage: {
@@ -246,7 +253,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       singleSignOut: false,
       logoutRedirect: {
         parameterName: 'post_logout_redirect_uri',
-        urlPattern: /\/oidc\/session\/end$/,
+        url: providerEndpoint(
+          process.env.NUXT_OIDC_PROVIDERS_LOGTO_BASE_URL || '',
+          'oidc/session/end',
+        ),
       },
     },
     config: automatedProviderOptions.logto,
@@ -266,7 +276,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       singleSignOut: false,
       logoutRedirect: {
         parameterName: 'post_logout_redirect_uri',
-        urlPattern: /^https:\/\/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/logout$/,
+        url: microsoftLogoutUrl,
       },
     },
     config: automatedProviderOptions.microsoft,
@@ -301,7 +311,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       singleSignOut: false,
       logoutRedirect: {
         parameterName: 'post_logout_redirect_uri',
-        urlPattern: /\/oidc\/v1\/end_session$/,
+        url: providerEndpoint(zitadelBaseUrl, 'oidc/v1/end_session'),
       },
     },
     loginPage: {

--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -59,6 +59,8 @@ export const automatedProviderOptions = {
     allowedCallbackRedirectUrls: [appOrigin],
     clientId: process.env.NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_ID || '',
     clientSecret: process.env.NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_SECRET || '',
+    logoutRedirectUri: appOrigin,
+    logoutUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout',
     redirectUri: callback('microsoft'),
   },
   oidc: {
@@ -174,7 +176,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
-      logoutRedirect: true,
+      logoutRedirect: {
+        parameterName: 'logout_uri',
+        urlPattern: /\/logout$/,
+      },
     },
     config: automatedProviderOptions.cognito,
   },
@@ -194,7 +199,11 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
-      logoutRedirect: true,
+      logoutRedirect: {
+        parameterName: 'post_logout_redirect_uri',
+        urlPattern:
+          /^https:\/\/(?:login\.microsoftonline\.com|[^/]+\.ciamlogin\.com)\/.+\/oauth2\/v2\.0\/logout$/,
+      },
     },
     loginPage: {
       open: async (page, loginUrl) => {
@@ -235,7 +244,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
-      logoutRedirect: true,
+      logoutRedirect: {
+        parameterName: 'post_logout_redirect_uri',
+        urlPattern: /\/oidc\/session\/end$/,
+      },
     },
     config: automatedProviderOptions.logto,
   },
@@ -252,7 +264,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
-      logoutRedirect: true,
+      logoutRedirect: {
+        parameterName: 'post_logout_redirect_uri',
+        urlPattern: /^https:\/\/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/logout$/,
+      },
     },
     config: automatedProviderOptions.microsoft,
   },
@@ -284,7 +299,10 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
-      logoutRedirect: true,
+      logoutRedirect: {
+        parameterName: 'post_logout_redirect_uri',
+        urlPattern: /\/oidc\/v1\/end_session$/,
+      },
     },
     loginPage: {
       open: async (page, loginUrl) => {

--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -4,7 +4,7 @@ import { withHttps } from 'ufo'
 
 const appOrigin = process.env.NUXT_OIDC_TEST_APP_ORIGIN || 'http://localhost:31840'
 const callback = (provider: string) => `${appOrigin}/auth/${provider}/callback`
-const entraTenantId = process.env.NUXT_OIDC_PROVIDERS_ENTRA_TENANT_ID || ''
+const entraAuthorizationUrl = process.env.NUXT_OIDC_PROVIDERS_ENTRA_AUTHORIZATION_URL || ''
 const zitadelBaseUrl = process.env.NUXT_OIDC_PROVIDERS_ZITADEL_BASE_URL || ''
 
 export const automatedProviderOptions = {
@@ -33,11 +33,13 @@ export const automatedProviderOptions = {
   },
   entra: {
     allowedCallbackRedirectUrls: [appOrigin],
-    authorizationUrl: `https://login.microsoftonline.com/${entraTenantId}/oauth2/v2.0/authorize`,
+    authorizationUrl: entraAuthorizationUrl,
     clientId: process.env.NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_ID || '',
     clientSecret: process.env.NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_SECRET || '',
+    logoutRedirectUri: appOrigin,
+    logoutUrl: process.env.NUXT_OIDC_PROVIDERS_ENTRA_LOGOUT_URL || '',
     redirectUri: callback('entra'),
-    tokenUrl: `https://login.microsoftonline.com/${entraTenantId}/oauth2/v2.0/token`,
+    tokenUrl: process.env.NUXT_OIDC_PROVIDERS_ENTRA_TOKEN_URL || '',
   },
   github: {
     allowedCallbackRedirectUrls: [appOrigin],
@@ -125,7 +127,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       'NUXT_OIDC_PROVIDERS_APPLE_CLIENT_ID',
       'NUXT_OIDC_PROVIDERS_APPLE_CLIENT_SECRET',
     ],
-    mode: 'online',
+    mode: 'excluded',
     authorizationUrlPattern: /^https:\/\/appleid\.apple\.com\/auth\/oauth2\/v2\/authorize$/,
     capabilities: {
       fullLogin: false,
@@ -181,15 +183,26 @@ export const providerConfigs: readonly TestProviderConfig[] = [
     requiredEnvVars: [
       'NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_ID',
       'NUXT_OIDC_PROVIDERS_ENTRA_CLIENT_SECRET',
-      'NUXT_OIDC_PROVIDERS_ENTRA_TENANT_ID',
+      'NUXT_OIDC_PROVIDERS_ENTRA_AUTHORIZATION_URL',
+      'NUXT_OIDC_PROVIDERS_ENTRA_TOKEN_URL',
+      'NUXT_OIDC_PROVIDERS_ENTRA_LOGOUT_URL',
     ],
     mode: 'online',
-    authorizationUrlPattern: /login\.microsoftonline\.com\/.+\/oauth2\/v2\.0\/authorize$/,
+    authorizationUrlPattern:
+      /^https:\/\/(?:login\.microsoftonline\.com|[^/]+\.ciamlogin\.com)\/.+\/oauth2\/v2\.0\/authorize$/,
     capabilities: {
       fullLogin: false,
       refresh: true,
       singleSignOut: false,
       logoutRedirect: true,
+    },
+    loginPage: {
+      open: async (page, loginUrl) => {
+        await page.goto(loginUrl)
+        const entraOrigin = new URL(entraAuthorizationUrl).origin
+        await page.waitForURL((url) => url.origin === entraOrigin)
+      },
+      selector: 'input[name="username"], input[name="loginfmt"]',
     },
     config: automatedProviderOptions.entra,
   },

--- a/test/setup/env-validator.ts
+++ b/test/setup/env-validator.ts
@@ -28,7 +28,7 @@ export function validateProviderEnv(providerName: string): EnvValidationResult {
 
   return {
     provider: providerName,
-    configured: missingVars.length === 0,
+    configured: config.mode !== 'excluded' && missingVars.length === 0,
     missingVars,
     presentVars,
   }
@@ -57,6 +57,7 @@ export function isProviderConfigured(providerName: string): boolean {
   const config = providerConfigs.find(({ name }) => name === providerName)
 
   if (config?.mode === 'dex') return true
+  if (config?.mode === 'excluded') return false
 
   return validateProviderEnv(providerName).configured
 }
@@ -74,6 +75,8 @@ export function printConfigurationStatus(): void {
 
     if (config?.mode === 'dex') {
       statusText = 'dex'
+    } else if (config?.mode === 'excluded') {
+      statusText = 'excluded'
     } else if (result.missingVars.length > 0) {
       statusText = `missing: ${result.missingVars.map((value) => value.replace('NUXT_OIDC_PROVIDERS_', '').replace(UNDERSCORE_RE, ' ')).join(', ')}`
     }

--- a/test/setup/types.ts
+++ b/test/setup/types.ts
@@ -19,7 +19,7 @@ export interface TestProviderConfig {
   requiredEnvVars: readonly string[]
 
   /** Provider runtime used by the automated matrix */
-  mode: 'dex' | 'online'
+  mode: 'dex' | 'online' | 'excluded'
 
   /** Expected authorization endpoint */
   authorizationUrlPattern: RegExp

--- a/test/setup/types.ts
+++ b/test/setup/types.ts
@@ -33,7 +33,7 @@ export interface TestProviderConfig {
       | false
       | {
           parameterName: string
-          urlPattern: RegExp
+          url: string
         }
   }
 

--- a/test/setup/types.ts
+++ b/test/setup/types.ts
@@ -29,7 +29,12 @@ export interface TestProviderConfig {
     fullLogin: boolean
     refresh: boolean
     singleSignOut: boolean
-    logoutRedirect: boolean
+    logoutRedirect:
+      | false
+      | {
+          parameterName: string
+          urlPattern: RegExp
+        }
   }
 
   /** Provider-hosted login page automation */


### PR DESCRIPTION
## Summary

- use existing Entra authorization, token, and logout endpoint secrets instead of synthesizing workforce endpoints from a tenant ID
- validate both redirect construction and the hosted Entra login page with the CI callback
- keep Apple explicitly excluded from automated provider tests

## Why

The test fixture expected a tenant ID that is not part of the existing SecretSpec layout. The configured app uses Entra External ID and already stores its `.ciamlogin.com` endpoints.

## Testing

I tested the Entra redirect, custom callback, hosted login page, and logout redirect locally through SecretSpec. The full provider matrix, formatting, lint, and typechecks pass.