### PR TITLE
test: exclude PayPal provider

### DIFF
--- a/test/fixtures/providers.ts
+++ b/test/fixtures/providers.ts
@@ -294,7 +294,7 @@ export const providerConfigs: readonly TestProviderConfig[] = [
       'NUXT_OIDC_PROVIDERS_PAYPAL_CLIENT_ID',
       'NUXT_OIDC_PROVIDERS_PAYPAL_CLIENT_SECRET',
     ],
-    mode: 'online',
+    mode: 'excluded',
     authorizationUrlPattern: /^https:\/\/www\.sandbox\.paypal\.com\/signin\/authorize$/,
     capabilities: {
       fullLogin: false,


### PR DESCRIPTION
Temporarily excludes PayPal from the automated provider matrix while its sandbox credentials remain invalid.

PayPal stays implemented in production; only provider E2E selection changes. Local SecretSpec runs confirm PayPal skips even when vault entries are present, while remaining configured providers pass.