### PR TITLE
fix(release): publish with npm trusted identity

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,0 +1,1 @@
+jdamaschke@visorian.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGG50kG0J/BIMV+nkxeP2fQmIjQh2+SGVqB5N5GFANTG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,17 @@ jobs:
     steps:
       - name: Require main dispatch
         run: test "$GITHUB_REF" = refs/heads/main
-      - name: Checkout signed tag
+      - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
+      - name: Verify and checkout signed tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
+          git -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers verify-tag "$RELEASE_TAG"
+          git checkout --detach "$RELEASE_TAG"
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Publish npm release
+
+run-name: Publish ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Signed release tag
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Require main dispatch
+        run: test "$GITHUB_REF" = refs/heads/main
+      - name: Checkout signed tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - name: Check npm trusted-publishing support
+        run: |
+          npm_version="$(pnpm exec npm --version)"
+          node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)" "$npm_version"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Publish signed release
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: pnpm release:publish -- "$GITHUB_SHA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - **logout:** Preserve per-call redirect URI ([#201](https://github.com/itpropro/nuxt-oidc-auth/pull/201))
 - **deps:** Remediate release security alerts ([#230](https://github.com/itpropro/nuxt-oidc-auth/pull/230))
 - **release:** Enforce artifact provenance ([#231](https://github.com/itpropro/nuxt-oidc-auth/pull/231))
+- **release:** Publish through tokenless GitHub OIDC
 
 ### 💅 Refactors
 

--- a/docs/content/99.contributing.md
+++ b/docs/content/99.contributing.md
@@ -70,14 +70,21 @@ gh workflow run e2e-providers.yml --ref main
 ```
 
 Confirm workflow run succeeded and its `headSha` equals `$release_commit`. Configured
-online-provider and Dex rows must pass; Apple and PayPal remain excluded. Publish only
-exact verified commit:
+online-provider and Dex rows must pass; Apple and PayPal remain excluded. Create and push
+signed tag only from exact verified commit:
 
 ```bash
-pnpm release:publish -- "$release_commit"
+pnpm release:tag -- "$release_commit"
 ```
 
-Publication refuses dirty trees, commits other than `origin/main`, mismatched provider-test
-commit, missing changelog entry, existing npm version, or existing/mismatched tag. It creates
-signed tag, validates tag-to-commit identity, publishes package, then pushes tag. Existing
+Tagging refuses dirty trees, commits other than `origin/main`, mismatched provider-test commit,
+missing changelog entry, existing npm version, or existing/mismatched tag. Existing
 `v1.0.0-beta.11` tag must remain untouched.
+
+Configure [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) for GitHub
+organization/user `itpropro`, repository `nuxt-oidc-auth`, workflow filename `release.yml`, no
+environment, and allow `npm publish`.
+After signed-tag Provider E2E succeeds, dispatch **Publish npm release** from `main` with tag
+name. Workflow requires signed tag, exact `origin/main` commit, matching changelog/package
+version, and unpublished npm version. GitHub OIDC publishes without repository npm credentials
+and npm automatically records provenance.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "OIDC authentication module for Nuxt SSR",
   "homepage": "https://github.com/itpropro/nuxt-oidc-auth#readme",
   "license": "MIT",
-  "repository": "itpropro/nuxt-oidc-auth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/itpropro/nuxt-oidc-auth.git"
+  },
   "files": [
     "dist"
   ],
@@ -28,6 +31,7 @@
     "dev:docs": "nuxi dev docs",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground && nuxi prepare client",
     "release:prepare": "node scripts/release.ts prepare",
+    "release:tag": "node scripts/release.ts tag",
     "release:publish": "node scripts/release.ts publish",
     "lint": "pnpm lint:ox && pnpm lint:eslint",
     "lint:ox": "oxlint -c oxlint.json --type-aware --tsconfig tsconfig.json --report-unused-disable-directives .",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -25,6 +25,11 @@ export interface PublicationState extends RepositoryState {
   verifiedCommit: string
 }
 
+export interface CIPublicationState extends PublicationState {
+  localTagCommit: string
+  remoteTagCommit: string
+}
+
 interface PreparationState extends RepositoryState {
   changelog: string
   currentVersion: string
@@ -91,10 +96,10 @@ function assertExactOriginMain(state: RepositoryState) {
   }
 }
 
-function assertPublicationRepositoryState(state: RepositoryState) {
+function assertTaggingRepositoryState(state: RepositoryState) {
   assertExactOriginMain(state)
   if (state.branch !== 'main') {
-    throw new Error(`Release must run on main; found ${state.branch ?? 'detached HEAD'}`)
+    throw new Error(`Tagging must run on main; found ${state.branch ?? 'detached HEAD'}`)
   }
 }
 
@@ -133,8 +138,7 @@ export function assertPreparationState(state: PreparationState) {
   )
 }
 
-export function assertPublicationState(state: PublicationState) {
-  assertPublicationRepositoryState(state)
+function assertReleaseContents(state: PublicationState) {
   validateVersion(state.packageVersion)
   if (state.verifiedCommit !== state.head) {
     throw new Error(`Provider E2E commit ${state.verifiedCommit} does not match HEAD ${state.head}`)
@@ -143,12 +147,35 @@ export function assertPublicationState(state: PublicationState) {
     throw new Error(`CHANGELOG.md is missing "## v${state.packageVersion}"`)
   }
   if (state.npmVersion) throw new Error(`npm version ${state.npmVersion} already exists`)
+}
+
+export function assertTaggingState(state: PublicationState) {
+  assertTaggingRepositoryState(state)
+  assertReleaseContents(state)
   assertTagAvailable(
     `v${state.packageVersion}`,
     state.head,
     state.localTagCommit,
     state.remoteTagCommit,
   )
+}
+
+export function assertCIPublicationState(state: CIPublicationState) {
+  assertExactOriginMain(state)
+  if (state.branch !== undefined) {
+    throw new Error(`CI publication must use a detached tag checkout; found ${state.branch}`)
+  }
+  assertReleaseContents(state)
+
+  const tag = `v${state.packageVersion}`
+  for (const [location, commit] of [
+    ['Local', state.localTagCommit],
+    ['Remote', state.remoteTagCommit],
+  ] as const) {
+    if (commit !== state.head) {
+      throw new Error(`${location} tag ${tag} points to ${commit}, not HEAD ${state.head}`)
+    }
+  }
 }
 
 export function assertSignedTag(tag: string, tagCommit: string, head: string, contents: string) {
@@ -215,6 +242,19 @@ function collectTagState(packageName: string, version: string) {
   }
 }
 
+function verifySignedTag(tag: string, head: string) {
+  const tagCommit = localTagCommit(tag)
+  if (!tagCommit) throw new Error(`Unable to resolve tag ${tag}`)
+  const tagContents = git(['cat-file', '-p', `refs/tags/${tag}`]).stdout
+  assertSignedTag(tag, tagCommit, head, tagContents)
+  git([
+    '-c',
+    `gpg.ssh.allowedSignersFile=${resolve(repositoryRoot, '.github/release-allowed-signers')}`,
+    'verify-tag',
+    tag,
+  ])
+}
+
 function parsePrepareArguments(args: string[]) {
   const [version, flag, from, ...rest] = args
   if (!version || rest.length || (flag && flag !== '--from') || (flag === '--from' && !from)) {
@@ -254,19 +294,24 @@ function prepare(args: string[]) {
   )
 }
 
-function publish(args: string[]) {
+function parseVerifiedCommit(args: string[], command: 'tag' | 'publish') {
   const [verifiedCommit, ...rest] = args
   if (!verifiedCommit || rest.length) {
-    throw new Error('Usage: pnpm release:publish -- <provider-e2e-commit>')
+    throw new Error(`Usage: pnpm release:${command} -- <provider-e2e-commit>`)
   }
 
-  const packageJson = readPackageJson()
-  const resolvedVerifiedCommit = git([
+  return git([
     'rev-parse',
     '--verify',
     '--end-of-options',
     `${verifiedCommit}^{commit}`,
   ]).stdout.trim()
+}
+
+function tag(args: string[]) {
+  const resolvedVerifiedCommit = parseVerifiedCommit(args, 'tag')
+
+  const packageJson = readPackageJson()
   const state = {
     ...collectRepositoryState(),
     ...collectTagState(packageJson.name, packageJson.version),
@@ -274,37 +319,60 @@ function publish(args: string[]) {
     packageVersion: packageJson.version,
     verifiedCommit: resolvedVerifiedCommit,
   }
-  assertPublicationState(state)
+  assertTaggingState(state)
 
   const tag = `v${packageJson.version}`
-  let npmPublished = false
   git(['tag', '-s', tag, '-m', tag], { inherit: true })
   try {
-    const tagCommit = localTagCommit(tag)
-    if (!tagCommit) throw new Error(`Unable to resolve created tag ${tag}`)
-    const tagContents = git(['cat-file', '-p', `refs/tags/${tag}`]).stdout
-    assertSignedTag(tag, tagCommit, state.head, tagContents)
-
-    execute('pnpm', ['publish', '--access=public'], { inherit: true })
-    npmPublished = true
+    verifySignedTag(tag, state.head)
     git(['push', 'origin', `refs/tags/${tag}`], { inherit: true })
   } catch (error) {
-    if (!npmPublished) {
-      git(['tag', '--delete', tag], { inherit: true })
-    } else {
-      console.error(`npm publication succeeded. Recover by pushing existing signed tag ${tag}.`)
-    }
+    console.error(`Signed local tag ${tag} remains available for push recovery.`)
     throw error
   }
-  console.log(`Published ${packageJson.name}@${packageJson.version} and pushed signed tag ${tag}.`)
+  console.log(`Pushed signed tag ${tag}. Dispatch release.yml on main to publish it.`)
+}
+
+function publish(args: string[]) {
+  if (process.env.GITHUB_ACTIONS !== 'true') {
+    throw new Error('npm publication must run in GitHub Actions trusted publishing')
+  }
+
+  const resolvedVerifiedCommit = parseVerifiedCommit(args, 'publish')
+  const packageJson = readPackageJson()
+  const tag = `v${packageJson.version}`
+  if (process.env.RELEASE_TAG !== tag) {
+    throw new Error(
+      `Release workflow tag ${process.env.RELEASE_TAG ?? '<unset>'} must equal ${tag}`,
+    )
+  }
+  const tagState = collectTagState(packageJson.name, packageJson.version)
+  if (!tagState.localTagCommit || !tagState.remoteTagCommit) {
+    throw new Error(`Signed tag ${tag} must exist locally and on origin`)
+  }
+  const state: CIPublicationState = {
+    ...collectRepositoryState(),
+    ...tagState,
+    changelog: readChangelog(),
+    localTagCommit: tagState.localTagCommit,
+    packageVersion: packageJson.version,
+    remoteTagCommit: tagState.remoteTagCommit,
+    verifiedCommit: resolvedVerifiedCommit,
+  }
+  assertCIPublicationState(state)
+
+  verifySignedTag(tag, state.head)
+  execute('pnpm', ['exec', 'npm', 'publish', '--access=public'], { inherit: true })
+  console.log(`Published ${packageJson.name}@${packageJson.version} from signed tag ${tag}.`)
 }
 
 function main() {
   const [command, ...args] = process.argv.slice(2)
   const commandArgs = args[0] === '--' ? args.slice(1) : args
   if (command === 'prepare') return prepare(commandArgs)
+  if (command === 'tag') return tag(commandArgs)
   if (command === 'publish') return publish(commandArgs)
-  throw new Error('Usage: release.ts <prepare|publish> [...args]')
+  throw new Error('Usage: release.ts <prepare|tag|publish> [...args]')
 }
 
 const entrypoint = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -323,11 +323,17 @@ function tag(args: string[]) {
 
   const tag = `v${packageJson.version}`
   git(['tag', '-s', tag, '-m', tag], { inherit: true })
+  let verified = false
   try {
     verifySignedTag(tag, state.head)
+    verified = true
     git(['push', 'origin', `refs/tags/${tag}`], { inherit: true })
   } catch (error) {
-    console.error(`Signed local tag ${tag} remains available for push recovery.`)
+    if (verified) {
+      console.error(`Signed local tag ${tag} remains available for push recovery.`)
+    } else {
+      git(['tag', '--delete', tag], { inherit: true })
+    }
     throw error
   }
   console.log(`Pushed signed tag ${tag}. Dispatch release.yml on main to publish it.`)

--- a/test/unit/release/provenance.test.ts
+++ b/test/unit/release/provenance.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  assertCIPublicationState,
   assertPreparationState,
-  assertPublicationState,
   assertSignedTag,
+  assertTaggingState,
+  type CIPublicationState,
   type PublicationState,
 } from '../../../scripts/release'
 
@@ -23,14 +25,23 @@ function publicationState(overrides: Partial<PublicationState> = {}): Publicatio
   }
 }
 
+function ciPublicationState(overrides: Partial<CIPublicationState> = {}): CIPublicationState {
+  return {
+    ...publicationState({ branch: undefined }),
+    localTagCommit: head,
+    remoteTagCommit: head,
+    ...overrides,
+  }
+}
+
 describe('release provenance', () => {
-  it('accepts a clean unpublished exact-main release', () => {
-    expect(() => assertPublicationState(publicationState())).not.toThrow()
+  it('accepts clean exact-main tagging state', () => {
+    expect(() => assertTaggingState(publicationState())).not.toThrow()
   })
 
   it.each([
     [{ clean: false }, 'Working tree must be clean'],
-    [{ branch: 'release/beta.12' }, 'Release must run on main'],
+    [{ branch: 'release/beta.12' }, 'Tagging must run on main'],
     [{ branch: undefined }, 'detached HEAD'],
     [{ originMain: otherCommit }, 'must equal origin/main'],
     [{ verifiedCommit: otherCommit }, 'does not match HEAD'],
@@ -43,7 +54,26 @@ describe('release provenance', () => {
   ] satisfies Array<[Partial<PublicationState>, string]>)(
     'rejects invalid publication state %#',
     (overrides, message) => {
-      expect(() => assertPublicationState(publicationState(overrides))).toThrow(message)
+      expect(() => assertTaggingState(publicationState(overrides))).toThrow(message)
+    },
+  )
+
+  it('accepts a detached exact-main publish with matching signed-tag refs', () => {
+    expect(() => assertCIPublicationState(ciPublicationState())).not.toThrow()
+  })
+
+  it.each([
+    [{ clean: false }, 'Working tree must be clean'],
+    [{ branch: 'main' }, 'must use a detached tag checkout'],
+    [{ originMain: otherCommit }, 'must equal origin/main'],
+    [{ verifiedCommit: otherCommit }, 'does not match HEAD'],
+    [{ npmVersion: version }, `npm version ${version} already exists`],
+    [{ localTagCommit: otherCommit }, `Local tag v${version} points to`],
+    [{ remoteTagCommit: otherCommit }, `Remote tag v${version} points to`],
+  ] satisfies Array<[Partial<CIPublicationState>, string]>)(
+    'rejects invalid CI publication state %#',
+    (overrides, message) => {
+      expect(() => assertCIPublicationState(ciPublicationState(overrides))).toThrow(message)
     },
   )
 


### PR DESCRIPTION
## Summary

I split release publication into two guarded steps: local signed-tag creation and GitHub-hosted npm publication through OIDC. CI verifies exact `origin/main`, matching Provider E2E commit, tag identity, and SSH signature before invoking npm 11.

This removes long-lived npm credentials from release flow and enables automatic npm provenance. Contributing docs include exact trusted-publisher settings.

## Checks

Formatting, actionlint, lint, root/client typechecks, unit and functional tests, prepack, and package dry-run pass locally. Cryptographic verification of a test SSH tag passes against committed public signer.

Part of #227.