### PR TITLE
fix(session): refresh opaque tokens by provider expiry

### DIFF
--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -268,8 +268,8 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
       const persistentSession: PersistentSession = {
         createdAt: new Date(),
         updatedAt: new Date(),
-        exp: accessToken.exp as number,
-        iat: accessToken.iat as number,
+        exp: accessToken.exp || timestamp + Number.parseInt(tokenResponse.expires_in),
+        iat: accessToken.iat || timestamp,
         accessToken: await encryptToken(tokenResponse.access_token, tokenKey),
         ...(tokenResponse.refresh_token && {
           refreshToken: await encryptToken(tokenResponse.refresh_token, tokenKey),

--- a/src/runtime/server/handler/callback.ts
+++ b/src/runtime/server/handler/callback.ts
@@ -265,11 +265,13 @@ function callbackEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
 
     if (tokenResponse.refresh_token || config.exposeAccessToken || config.exposeIdToken) {
       const tokenKey = process.env.NUXT_OIDC_TOKEN_KEY as string
+      const expiresIn = Number.parseInt(tokenResponse.expires_in)
       const persistentSession: PersistentSession = {
         createdAt: new Date(),
         updatedAt: new Date(),
-        exp: accessToken.exp || timestamp + Number.parseInt(tokenResponse.expires_in),
-        iat: accessToken.iat || timestamp,
+        exp:
+          accessToken.exp ?? (Number.isFinite(expiresIn) ? timestamp + expiresIn : user.expireAt),
+        iat: accessToken.iat ?? timestamp,
         accessToken: await encryptToken(tokenResponse.access_token, tokenKey),
         ...(tokenResponse.refresh_token && {
           refreshToken: await encryptToken(tokenResponse.refresh_token, tokenKey),

--- a/test/functional/opaque-session-refresh.test.ts
+++ b/test/functional/opaque-session-refresh.test.ts
@@ -23,6 +23,76 @@ afterEach(() => {
   vi.unstubAllEnvs()
 })
 
+async function invokeCallbackForExpiry(options: {
+  accessToken: string
+  expiresIn: string
+  skipAccessTokenParsing: boolean
+}) {
+  const harness = new HandlerHarness({
+    runtimeConfig: {
+      oidc: {
+        session: {
+          automaticRefresh: false,
+          expirationCheck: true,
+          maxAge: 3600,
+        },
+        providers: {
+          oidc: {
+            authorizationUrl: `${issuer}/authorize`,
+            clientId,
+            clientSecret: 'functional-secret',
+            redirectUri: 'https://app.example.test/auth/oidc/callback',
+            requiredProperties: [
+              'clientId',
+              'clientSecret',
+              'authorizationUrl',
+              'tokenUrl',
+              'redirectUri',
+            ],
+            skipAccessTokenParsing: options.skipAccessTokenParsing,
+            tokenUrl,
+            validateAccessToken: false,
+            validateIdToken: false,
+          },
+        },
+      },
+    },
+  })
+  harness.cookieJar.seedSession('oidc', {
+    codeVerifier: 'functional-code-verifier',
+    redirect: 'https://app.example.test/auth/oidc/callback',
+    state: 'functional-state',
+  })
+  interceptFetch([
+    {
+      method: 'POST',
+      url: tokenUrl,
+      respond: () =>
+        Response.json({
+          access_token: options.accessToken,
+          expires_in: options.expiresIn,
+          refresh_token: 'initial-refresh-token',
+          token_type: 'Bearer',
+        }),
+    },
+  ])
+  const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+  const callbackRequest = harness.createEvent({
+    path: '/auth/oidc/callback',
+    query: { code: 'functional-code', state: 'functional-state' },
+  })
+
+  await callbackHandler(callbackRequest.event)
+
+  const userSession = harness.inspectSession('nuxt-oidc-auth')
+  if (!userSession) throw new Error('Callback did not create a user session')
+  const persistentSession = harness.inspectStorage('oidc').get(userSession.id) as
+    | PersistentSession
+    | undefined
+  if (!persistentSession) throw new Error('Callback did not create a persistent session')
+  return { persistentSession, userSession }
+}
+
 describe('opaque access-token sessions', () => {
   it('uses token response expiry to trigger automatic refresh', async () => {
     const initialIdToken = await signingFixture.sign({
@@ -154,5 +224,28 @@ describe('opaque access-token sessions', () => {
     expect(refreshedSession).not.toHaveProperty('accessToken')
     expect(refreshedSession).not.toHaveProperty('idToken')
     expect(interceptor.requests.filter((request) => request.url === tokenUrl)).toHaveLength(2)
+  })
+
+  it('preserves explicit zero-valued JWT timestamps', async () => {
+    const accessToken = await signingFixture.sign({ exp: 0, iat: 0, sub: 'user-1' })
+
+    const { persistentSession } = await invokeCallbackForExpiry({
+      accessToken,
+      expiresIn: '3600',
+      skipAccessTokenParsing: false,
+    })
+
+    expect(persistentSession).toMatchObject({ exp: 0, iat: 0 })
+  })
+
+  it('falls back to session expiry when provider expiry is invalid', async () => {
+    const { persistentSession, userSession } = await invokeCallbackForExpiry({
+      accessToken: 'opaque-access-token',
+      expiresIn: 'not-a-number',
+      skipAccessTokenParsing: true,
+    })
+
+    expect(Number.isFinite(persistentSession.exp)).toBe(true)
+    expect(persistentSession.exp).toBe(userSession.data.expireAt)
   })
 })

--- a/test/functional/opaque-session-refresh.test.ts
+++ b/test/functional/opaque-session-refresh.test.ts
@@ -1,0 +1,158 @@
+import type { PersistentSession } from '../../src/runtime/types'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRs256Fixture, HandlerHarness, interceptFetch } from './handler-harness'
+
+const clientId = 'functional-client'
+const issuer = 'https://identity.example.test'
+const jwksUri = `${issuer}/jwks`
+const tokenUrl = `${issuer}/token`
+let signingFixture: Awaited<ReturnType<typeof createRs256Fixture>>
+
+beforeAll(async () => {
+  signingFixture = await createRs256Fixture()
+})
+
+beforeEach(() => {
+  vi.stubEnv('NUXT_OIDC_AUTH_SESSION_SECRET', 'test-auth-session-secret-at-least-32-characters')
+  vi.stubEnv('NUXT_OIDC_SESSION_SECRET', 'test-session-secret-at-least-32-characters')
+  vi.stubEnv('NUXT_OIDC_TOKEN_KEY', 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('opaque access-token sessions', () => {
+  it('uses token response expiry to trigger automatic refresh', async () => {
+    const initialIdToken = await signingFixture.sign({
+      aud: clientId,
+      iss: issuer,
+      role: 'initial-role',
+      sub: 'user-1',
+    })
+    const refreshedIdToken = await signingFixture.sign({
+      aud: clientId,
+      iss: issuer,
+      role: 'refreshed-role',
+      sub: 'user-1',
+    })
+    const tokenResponses = [
+      {
+        access_token: 'initial-opaque-access-token',
+        expires_in: '60',
+        id_token: initialIdToken,
+        refresh_token: 'initial-refresh-token',
+        token_type: 'Bearer',
+      },
+      {
+        access_token: 'refreshed-opaque-access-token',
+        expires_in: '3600',
+        id_token: refreshedIdToken,
+        refresh_token: 'rotated-refresh-token',
+        token_type: 'Bearer',
+      },
+    ]
+    let tokenResponseIndex = 0
+    const harness = new HandlerHarness({
+      runtimeConfig: {
+        oidc: {
+          session: {
+            automaticRefresh: true,
+            expirationCheck: true,
+            expirationThreshold: 120,
+            maxAge: 3600,
+          },
+          providers: {
+            oidc: {
+              authorizationUrl: `${issuer}/authorize`,
+              clientId,
+              clientSecret: 'functional-secret',
+              exposeAccessToken: false,
+              exposeIdToken: false,
+              openIdConfiguration: { issuer, jwks_uri: jwksUri },
+              optionalClaims: ['role'],
+              redirectUri: 'https://app.example.test/auth/oidc/callback',
+              requiredProperties: [
+                'clientId',
+                'clientSecret',
+                'authorizationUrl',
+                'tokenUrl',
+                'redirectUri',
+              ],
+              sessionConfiguration: {
+                automaticRefresh: true,
+                expirationCheck: true,
+                expirationThreshold: 120,
+              },
+              skipAccessTokenParsing: true,
+              tokenUrl,
+              tokenValidationMode: 'strict',
+              validateAccessToken: false,
+              validateIdToken: true,
+            },
+          },
+        },
+      },
+    })
+    harness.cookieJar.seedSession('oidc', {
+      codeVerifier: 'functional-code-verifier',
+      redirect: 'https://app.example.test/auth/oidc/callback',
+      state: 'functional-state',
+    })
+    const interceptor = interceptFetch([
+      {
+        method: 'POST',
+        url: tokenUrl,
+        respond: () => Response.json(tokenResponses[tokenResponseIndex++]!),
+      },
+      { url: jwksUri, respond: () => Response.json(signingFixture.jwks) },
+    ])
+    const callbackHandler = (await import('../../src/runtime/server/handler/callback')).default
+    const callbackRequest = harness.createEvent({
+      path: '/auth/oidc/callback',
+      query: { code: 'functional-code', state: 'functional-state' },
+    })
+    const beforeCallback = Math.trunc(Date.now() / 1000)
+
+    await callbackHandler(callbackRequest.event)
+    callbackRequest.commitResponseCookies()
+
+    const initialSession = harness.inspectSession('nuxt-oidc-auth')
+    if (!initialSession) throw new Error('Callback did not create a user session')
+    const persistentSession = harness.inspectStorage('oidc').get(initialSession.id) as
+      | PersistentSession
+      | undefined
+    if (!persistentSession) throw new Error('Callback did not create a persistent session')
+    expect(initialSession.data).toEqual(
+      expect.objectContaining({
+        canRefresh: true,
+        claims: { role: 'initial-role' },
+        provider: 'oidc',
+      }),
+    )
+    expect(initialSession.data).not.toHaveProperty('accessToken')
+    expect(initialSession.data).not.toHaveProperty('idToken')
+    expect(persistentSession.exp).toBeGreaterThanOrEqual(beforeCallback + 60)
+    expect(persistentSession.exp).toBeLessThanOrEqual(Math.trunc(Date.now() / 1000) + 60)
+    expect(persistentSession.iat).toBeGreaterThanOrEqual(beforeCallback)
+    expect(initialSession.data.expireAt).toBeGreaterThan(persistentSession.exp)
+
+    const { getUserSession } = await import('../../src/runtime/server/utils/session')
+    const sessionRequest = harness.createEvent({ path: '/api/_auth/session' })
+    const refreshedSession = await getUserSession(sessionRequest.event, {
+      errorBehavior: 'throw',
+    })
+
+    expect(refreshedSession).toEqual(
+      expect.objectContaining({
+        canRefresh: true,
+        claims: { role: 'refreshed-role' },
+        provider: 'oidc',
+      }),
+    )
+    expect(refreshedSession).not.toHaveProperty('accessToken')
+    expect(refreshedSession).not.toHaveProperty('idToken')
+    expect(interceptor.requests.filter((request) => request.url === tokenUrl)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Opaque access tokens do not carry parsed `exp` or `iat` claims. I now persist the token endpoint's `expires_in` value and callback timestamp, allowing automatic refresh to use provider expiry instead of an undefined persistent expiry.

I added provider-agnostic functional coverage for strict ID-token validation, optional claim replacement, hidden tokens, and callback-to-automatic-refresh behavior. Tested with the full Vitest suite, lint, formatting, Nuxt and TypeScript checks, plus the offline Dex browser suite.