### PR TITLE
fix(docs): preserve external navigation links

### DIFF
--- a/docs/app/app.vue
+++ b/docs/app/app.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 const { seo } = useAppConfig()
 
-const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
+const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs', [
+  'to',
+  'external',
+  'target',
+]))
 const { data: files } = await useAsyncData('search-sections', () => queryCollectionSearchSections('docs', {
   ignoredTags: ['style'],
 }))

--- a/docs/app/components/DocsNavigation.vue
+++ b/docs/app/components/DocsNavigation.vue
@@ -7,6 +7,14 @@ defineProps<{
   navigation: ContentNavigationItem[]
   nested?: boolean
 }>()
+
+function linkDestination(link: ContentNavigationItem) {
+  return typeof link.to === 'string' ? link.to : link.path
+}
+
+function linkTarget(link: ContentNavigationItem) {
+  return link.target === '_blank' ? '_blank' : undefined
+}
 </script>
 
 <template>
@@ -14,7 +22,9 @@ defineProps<{
     <li v-for="link in navigation" :key="link.path || link.title">
       <ULink
         v-if="link.path && !link.children?.length"
-        :to="link.path"
+        :to="linkDestination(link)"
+        :external="link.external === true"
+        :target="linkTarget(link)"
         class="flex items-center gap-2 py-1.5 text-sm text-muted hover:text-highlighted"
         active-class="font-medium text-primary"
       >

--- a/docs/app/error.vue
+++ b/docs/app/error.vue
@@ -19,7 +19,11 @@ useHead({
   },
 })
 
-const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
+const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs', [
+  'to',
+  'external',
+  'target',
+]))
 const { data: files } = await useAsyncData('search-sections', () => queryCollectionSearchSections('docs', {
   ignoredTags: ['style'],
 }))

--- a/docs/test/docs.smoke.spec.ts
+++ b/docs/test/docs.smoke.spec.ts
@@ -52,5 +52,12 @@ test('generated docs render direct routes and client navigation', async ({ page 
   await expect(page).toHaveURL(`${origin}/configuration`)
   await page.getByRole('link', { name: 'Security', exact: true }).first().click()
   await expect(page).toHaveURL(`${origin}/getting-started/security`)
+
+  const changelogLink = page.getByRole('link', { name: 'Changelog', exact: true }).first()
+  await expect(changelogLink).toHaveAttribute(
+    'href',
+    'https://github.com/itpropro/nuxt-oidc-auth/blob/main/CHANGELOG.md',
+  )
+  await expect(changelogLink).toHaveAttribute('target', '_blank')
   await assertClean()
 })


### PR DESCRIPTION
Docs navigation now includes custom `to`, `external`, and `target` metadata and passes it to `ULink`. This keeps the Changelog entry pointed at the GitHub changelog instead of the generated internal route.

Checks run locally: docs lint and typecheck, formatting, static generation with link inspection, and rendered smoke coverage.