### PR TITLE
fix: harden authentication defaults and dev-mode gating

### DIFF
--- a/docs/content/1.getting-started/3.security.md
+++ b/docs/content/1.getting-started/3.security.md
@@ -41,7 +41,7 @@ Here is an example configuration. You can also replace the storage by any suppor
 ### Configure secrets
 
 Nuxt OIDC Auth uses three different secrets to encrypt the user session, the individual auth sessions and the persistent server side token store. You can set them using environment variables or in the `.env` file.
-All of the secrets are auto generated if not set, but should be set manually in production. This is especially important for the session storage, as it won't be accessible anymore if the secret changes, for example, after a server restart.
+All of the secrets are auto generated if not set, but should be set manually in production. This is especially important for the session storage, as it won't be accessible anymore if the secret changes, for example, after a server restart. Auto generated secrets are masked in logs (only the first few characters are shown) unless dev mode is enabled, so they are never printed in full outside local development.
 
 If a refreshable cookie session still exists but its persistent `oidc` storage entry is missing (for example after container or storage changes), the module clears the stale session by default and requires a fresh login. You can change this behavior with `session.missingPersistentSession` (`clear`, `warn`, `silent`).
 
@@ -64,7 +64,7 @@ NUXT_OIDC_AUTH_SESSION_SECRET=48_characters_random_string
 
 ID and access token validation involves verifying the integrity and claims of the ID token (usually a JWT) to authenticate the user, and validating the access token by checking its signature, expiration, issuer, and audience to ensure it grants appropriate permissions for resource access. This is critical to prevent token tampering, misuse, and unauthorized access to protected APIs or services.
 
-We use the well-known and tested `jose` library for JWT validation. Configure provider-level `tokenValidationMode: 'strict'` to validate every enabled JWT in callback and refresh token responses without trusting its decoded claims first. Strict validation verifies signature, expiration, issuer, and token-specific audience:
+We use the well-known and tested `jose` library for JWT validation. Strict validation is the default (`tokenValidationMode: 'strict'`) and validates every enabled JWT in callback and refresh token responses without trusting its decoded claims first. Strict validation verifies signature, expiration, issuer, and token-specific audience:
 
 - Access tokens use configured `audience`.
 - ID tokens use configured `clientId` and require `sub` and `iat`. Present `azp` must match `clientId`, and multi-audience ID tokens require it. Callback ID tokens also require a matching authentication-request nonce when nonce is enabled. Refreshed ID tokens must retain the original ID-token subject and, when present, authentication time.
@@ -72,7 +72,7 @@ We use the well-known and tested `jose` library for JWT validation. Configure pr
 Strict access-token validation requires `audience`. Any enabled strict validation requires OpenID discovery metadata containing `issuer` and `jwks_uri`. If `validateIdToken` is enabled, token response must include an ID token.
 
 ::callout{icon="i-carbon-warning-alt" color="amber"}
-`legacy` remains default for current production line. During callbacks, it validates enabled tokens only when decoded `aud` exactly equals configured audience or client ID, and emits one migration warning per provider when validation is skipped. Refresh responses retain existing parsing behavior. Migrate providers issuing JWTs to `strict` after configuring required audience and discovery metadata. `strict` is intended to become default in next explicitly breaking release.
+`legacy` is now an opt-in backwards-compatibility mode (`strict` is the default). During callbacks, `legacy` validates enabled tokens only when the decoded `aud` exactly equals the configured audience or client ID, otherwise it trusts the decoded claims and emits one migration warning per provider when validation is skipped. Refresh responses retain the legacy parsing behavior. Only opt into `legacy` for backwards compatibility; providers issuing opaque access tokens should keep `validateAccessToken: false` / `skipAccessTokenParsing: true` instead of falling back to `legacy`.
 ::
 
 Strict refresh validation runs before session or persistent token state is updated. Invalid responses use existing refresh failure handling to clear stale session state.
@@ -80,3 +80,7 @@ Strict refresh validation runs before session or persistent token state is updat
 Some providers, including Auth0 configurations without API audience, may issue opaque access tokens. Preserve support explicitly with `validateAccessToken: false` and `skipAccessTokenParsing: true`; ID-token validation can remain enabled independently. `tokenValidationMode: 'strict'` does not override these opt-outs and validates only token types enabled by their `validate*Token` flag.
 
 Offline end-to-end tests use the generic `oidc` fixture with deterministic test-only signing keys, matching discovery and JWKS metadata, and strict access-token and ID-token validation. Integrated coverage exercises login, refresh, logout, and rejection of invalid signatures, issuer or audience mismatches, and nonce mismatches without a live identity provider.
+
+## Cross-site request protection
+
+The session cookie uses `SameSite=Lax` by default. In addition, the state-changing session endpoints — `DELETE /api/_auth/session` (used by `logout()`) and `POST /api/_auth/refresh` (used by `refresh()`) — reject cross-origin requests with a `403`. A request is considered cross-origin when its `Origin` (or, as a fallback, `Referer`) header does not match the request target. Requests without an `Origin` or `Referer` header (for example server-to-server API clients) are allowed. If you call these endpoints from a different origin, send matching credentials from the same origin or call them server-side.

--- a/docs/content/2.provider/3.aws-cognito.md
+++ b/docs/content/2.provider/3.aws-cognito.md
@@ -36,7 +36,8 @@ cognito: {
   scope: ['openid', 'email', 'profile'],
   logoutRedirectUri: 'https://google.com',
   baseUrl: '',
-  exposeIdToken: true, // This is necessary to validate the logout redirect. If you don't need the ID token and don't use a logout redirect, set this to false.
+  // Keep the ID token server-side by default. Set to true only if the client needs to read it.
+  exposeIdToken: false,
 },
 ```
 

--- a/docs/content/2.provider/6.keycloak.md
+++ b/docs/content/2.provider/6.keycloak.md
@@ -75,8 +75,8 @@ By default, the following settings are already set internally, but can be overwr
 - `logoutUrl`: `protocol/openid-connect/logout`,
 - `logoutRedirectParameterName`: `post_logout_redirect_uri`,
 
-::callout{icon="i-carbon-warning-alt" color="amber"}
-If you want to use the post logout redirect feature, you should not set `exposeIdToken` to `false`, because the ID token is required to hand over to the post logout redirect url.
+::callout{icon="i-carbon-information" color="blue"}
+The post logout redirect feature keeps working with the default `exposeIdToken: false`. The `id_token_hint` is read from the encrypted server-side session, so the ID token is no longer sent to the client just to support logout. Only enable `exposeIdToken` if the client itself needs to read the ID token.
 ::
 
 ### Environment variables

--- a/docs/content/2.provider/7.logto.md
+++ b/docs/content/2.provider/7.logto.md
@@ -57,3 +57,7 @@ The Logto provider supports several specific parameters to customize the authent
 | prompt | `'login' \| 'none' \| 'consent' \| 'select_account'` | `consent` | Controls the authentication behavior: 'login' forces authentication, 'none' prevents interaction, 'consent' requires explicit consent, and 'select_account' allows account selection. |
 
 For Logto you have to provide at least the `baseUrl`, `clientId` and `clientSecret` properties. The `baseUrl` is used to dynamically create the `authorizationUrl`, `tokenUrl`, `logoutUrl` and `userInfoUrl`.
+
+::callout{icon="i-carbon-information" color="blue"}
+The ID token is kept server-side by default (`exposeIdToken: false`). RP-initiated logout still works because `id_token_hint` is read from the encrypted server-side session. Only enable `exposeIdToken` if the client needs to read the ID token.
+::

--- a/docs/content/2.provider/8.microsoft.md
+++ b/docs/content/2.provider/8.microsoft.md
@@ -37,7 +37,7 @@ Never store sensitive values like your client secret in your Nuxt config. Our re
 ### Minimal
 
 ```typescript [nuxt.config.ts]
-entra: {
+microsoft: {
   redirectUri: 'http://localhost:3000/auth/microsoft/callback',
   clientId: '',
   clientSecret: '',
@@ -49,7 +49,7 @@ entra: {
 You can also add the `profile` or another OIDC common scope. `User.Read` as a delegated permission is configured by default in **API permissons**.
 
 ```typescript [nuxt.config.ts]
-entra: {
+microsoft: {
   redirectUri: 'http://localhost:3000/auth/microsoft/callback',
   clientId: '',
   clientSecret: '',
@@ -65,7 +65,7 @@ To add additional claims you want to use, configure them on your app registratio
 The default setting is `optionalClaims: ['name', 'preferred_username'],`.
 
 ```typescript [nuxt.config.ts]
-entra: {
+microsoft: {
   redirectUri: 'http://localhost:3000/auth/microsoft/callback',
   clientId: '',
   clientSecret: '',
@@ -83,7 +83,7 @@ In order to get a refresh token, you need to add the "Microsoft Graph" delegated
 ::
 
 ```typescript [nuxt.config.ts]
-entra: {
+microsoft: {
   redirectUri: 'http://localhost:3000/auth/microsoft/callback',
   clientId: '',
   clientSecret: '',
@@ -106,7 +106,7 @@ NUXT_OIDC_PROVIDERS_MICROSOFT_CLIENT_ID=CLIENT_ID
 | Option | Type | Default | Description |
 |---|---|---|---|
 | tenantId | `string` | - | Required. The tenant id is used to automatically configure the correct endpoint urls for the Microsoft provider to work. |
-| prompt | `string` | 'login' | Optional. Indicates the type of user interaction that is required. Valid values are `login`, `none`, `consent`, and `select_account`. Can be used in `additionalAuthParameters`, `additionalTokenParameters` or `additionalLogoutParameters`. |
+| prompt | `string` | 'select_account' | Optional. Indicates the type of user interaction that is required. Valid values are `login`, `none`, `consent`, and `select_account`. Can be used in `additionalAuthParameters`, `additionalTokenParameters` or `additionalLogoutParameters`. |
 | loginHint | `string` | - | Optional. You can use this parameter to pre-fill the username and email address field of the sign-in page for the user. Apps can use this parameter during reauthentication, after already extracting the login_hint optional claim from an earlier sign-in. Can be used in `additionalAuthParameters`, `additionalTokenParameters` or `additionalLogoutParameters`. |
 | logoutHint | `string` | - | Optional. Enables sign-out to occur without prompting the user to select an account. To use logout_hint, enable the login_hint optional claim in your client application and use the value of the login_hint optional claim as the logout_hint parameter. Can be used in `additionalAuthParameters`, `additionalTokenParameters` or `additionalLogoutParameters`. |
 | domainHint | `string` | - | Optional. If included, the app skips the email-based discovery process that user goes through on the sign-in page, leading to a slightly more streamlined user experience. Can be used in `additionalAuthParameters`, `additionalTokenParameters` or `additionalLogoutParameters`. |

--- a/docs/content/2.provider/99.oidc.md
+++ b/docs/content/2.provider/99.oidc.md
@@ -21,7 +21,7 @@ const defaults: Partial<OidcProviderConfig> = {
   responseType: 'code',
   authenticationScheme: 'header',
   grantType: 'authorization_code',
-  pkce: false,
+  pkce: true,
   state: true,
   nonce: false,
   scope: ['openid'],
@@ -36,13 +36,21 @@ const defaults: Partial<OidcProviderConfig> = {
   ],
   validateAccessToken: true,
   validateIdToken: true,
+  tokenValidationMode: 'strict',
   skipAccessTokenParsing: false,
   exposeAccessToken: false,
   exposeIdToken: false,
   callbackRedirectUrl: '/',
   allowedClientAuthParameters: undefined,
   logoutUrl: '',
-  sessionConfiguration: undefined,
+  sessionConfiguration: {
+    automaticRefresh: true,
+    expirationThreshold: 0,
+    expirationCheck: true,
+    singleSignOut: false,
+    singleSignOutIdField: 'sub',
+    maxAuthSessionAge: undefined,
+  },
   additionalAuthParameters: undefined,
   additionalTokenParameters: undefined,
   additionalLogoutParameters: undefined,
@@ -80,6 +88,13 @@ oidc: {
 
 Dotenv files are only for (local) development. Use a proper configuration management or injection system in production.
 
+Any provider option can be supplied as an environment variable using the `NUXT_OIDC_PROVIDERS_OIDC_<OPTION>` prefix (screaming snake case). A typical minimal set:
+
 ```ini [.env]
-EVERY AVAILABLE PARAMETER
+NUXT_OIDC_PROVIDERS_OIDC_CLIENT_ID=CLIENT_ID
+NUXT_OIDC_PROVIDERS_OIDC_CLIENT_SECRET=CLIENT_SECRET
+NUXT_OIDC_PROVIDERS_OIDC_AUTHORIZATION_URL=https://issuer.example.com/authorize
+NUXT_OIDC_PROVIDERS_OIDC_TOKEN_URL=https://issuer.example.com/token
+NUXT_OIDC_PROVIDERS_OIDC_USER_INFO_URL=https://issuer.example.com/userinfo
+NUXT_OIDC_PROVIDERS_OIDC_REDIRECT_URI=http://localhost:3000/auth/oidc/callback
 ```

--- a/docs/content/5.dev-mode.md
+++ b/docs/content/5.dev-mode.md
@@ -5,7 +5,7 @@ description: Development mode for seamless local development
 
 ## Dev mode
 
-Since 0.10.0, there is a local dev mode available. It can only be enabled when `NODE_ENV` does not start with `prod`, case-insensitively, and dev mode is explicitly enabled in config. The dev mode is for ***local*** and ***offline*** development and returns a static user object that can be configured in config or by variables in `.env`.
+Since 0.10.0, there is a local dev mode available. It can only be enabled when running the Nuxt dev server (`nuxt dev`) and dev mode is explicitly enabled in config. Production builds (`nuxi build`/`generate`) never include the dev auth endpoints, regardless of `NODE_ENV`; a `NODE_ENV` starting with `prod` additionally disables them as defense in depth. The dev mode is for ***local*** and ***offline*** development and returns a static user object that can be configured in config or by variables in `.env`.
 
 The following fields in the returned [user object](/composable#user-object) can be configured:
 
@@ -37,7 +37,7 @@ Dev sessions bypass provider token-expiration and persistent-token checks, so gl
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `enabled` | `boolean` | `false` | Enables/disables dev mode. Ignored when `NODE_ENV` starts with `prod`, case-insensitively. |
+| `enabled` | `boolean` | `false` | Enables/disables dev mode. Only available on the dev server; stripped from production builds and additionally ignored when `NODE_ENV` starts with `prod`, case-insensitively. |
 | `userName` | `string` | `'Nuxt OIDC Auth Dev'` | Sets the `userName` field on the user object. |
 | `userInfo` | `Record<string, unknown>` | - | Sets the `userInfo` field on the user object. |
 | `claims` | `Record<string, string>` | - | Sets the claims field on the user object and generated JWT token. |

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -122,7 +122,7 @@ This helper is server-only and returns `EffectiveProviderConfig` for the selecte
 stored directly in `useRuntimeConfig(event).oidc.providers` use `ProviderRuntimeConfig`, the raw
 override shape. Do not treat that raw storage as resolved configuration or expose it to client code.
 
-`NODE_ENV` is classified as production when its value starts with `prod`, case-insensitively. This classification controls the default secure-cookie flag and disables dev mode. Values such as `production`, `prod`, and `PROD-preview` are production; an unset value is non-production.
+`NODE_ENV` is classified as production when its value starts with `prod`, case-insensitively. The default secure-cookie flag is resolved from this classification at runtime, so a production deployment gets `Secure` cookies even when the build did not run with a production `NODE_ENV` (an explicit `cookie.secure` value still takes precedence). It is also used as a secondary guard for the dev-mode endpoints. Values such as `production`, `prod`, and `PROD-preview` are production; an unset value is non-production. Dev mode itself is gated on the dev server and stripped from production builds regardless of `NODE_ENV` (see [Dev mode](/dev-mode)).
 
 ### Global session configuration (session)
 
@@ -139,7 +139,7 @@ Note that `singleSignOut` and `singleSignOutIdField` are provider specific optio
 | missingPersistentSession | `'clear' \| 'warn' \| 'silent'` | `'clear'` | Behavior when a refreshable cookie session exists but the persistent session entry is missing. `clear` removes stale session and requires re-login, `warn` keeps session and logs a warning, `silent` keeps session without warning |
 | maxAge | `number` | `60 * 60 * 24` (1 day) | Maximum user session duration in seconds |
 | maxAuthSessionAge | `number` | `300` (5 minutes) | Maximum OAuth flow/auth session duration in seconds |
-| cookie | `{ sameSite?: true \| false \| 'lax' \| 'strict' \| 'none'; secure?: boolean }` | `{ sameSite: 'lax', secure: NODE_ENV starts with 'prod' }` | Additional cookie setting overrides for `sameSite` and `secure` |
+| cookie | `{ sameSite?: true \| false \| 'lax' \| 'strict' \| 'none'; secure?: boolean }` | `{ sameSite: 'lax', secure: true in production }` | Additional cookie setting overrides for `sameSite` and `secure`. `secure` is resolved at runtime from `NODE_ENV` unless set explicitly. |
 
 ### Provider session configuration
 
@@ -171,7 +171,7 @@ For more details, please check the [dev mode docs page](/dev-mode)
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| enabled | `boolean` | `false` | Enables/disables the dev mode. Dev mode can only be enabled when the app runs in a non production environment. |
+| enabled | `boolean` | `false` | Enables/disables the dev mode. Dev mode is only available when running the dev server and is stripped from production builds. |
 | userName | `string` | `'Nuxt OIDC Auth Dev'` | Sets the `userName` field on the user object |
 | userInfo | `Record<string, unknown>` | `undefined` | Sets the `userInfo` field on the user object |
 | tokenAlgorithm | `'symmetric'` \| `'asymmetric'` | `'asymmetric'` | Sets the key algorithm for signing generated JWT tokens |
@@ -210,7 +210,6 @@ For more details, please check the [dev mode docs page](/dev-mode)
         scope: ['openid', 'email', 'profile'],
         logoutRedirectUri: 'https://google.com',
         baseUrl: '',
-        exposeIdToken: true,
       },
       zitadel: {
         clientId: '',

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -76,7 +76,7 @@ export default defineNuxtConfig({
 | openIdConfiguration | `string`, `Record<string, unknown>`, or `function (config) => Promise<Record<string, unknown>>` (optional) | `undefined` | OpenID Configuration URL, object, or function that resolves to an OpenID Configuration object. |
 | validateAccessToken | `boolean` (optional) | `true` | Validate access token. |
 | validateIdToken | `boolean` (optional) | `true` | Validate id token. |
-| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'legacy'` | `strict` validates every enabled JWT in callback and refresh token responses with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. |
+| tokenValidationMode | `'legacy'` \| `'strict'` (optional) | `'strict'` | `strict` validates every enabled JWT in callback and refresh token responses with token-specific audience, issuer, signature, and expiration checks. Strict access-token validation requires `audience`; any enabled strict validation requires OpenID discovery metadata with `issuer` and `jwks_uri`. `legacy` only verifies a token when its decoded (unverified) audience matches and otherwise trusts the decoded claims; use it only for backwards compatibility. |
 | encodeRedirectUri | `boolean` (optional) | `false` | Encode redirect uri query parameter in authorization request. Only for compatibility with services that don't implement proper parsing of query parameters. |
 | exposeAccessToken | `boolean` (optional) | `false` | Expose access token to the client within session object |
 | exposeIdToken | `boolean` (optional) | `false` | Expose raw id token to the client within session object |

--- a/docs/content/7.configuration.md
+++ b/docs/content/7.configuration.md
@@ -55,14 +55,16 @@ export default defineNuxtConfig({
 | redirectUri | `string` (optional) | '' | Redirect URI |
 | grantType | `'authorization_code'` \| `'refresh_token'` (optional) | `authorization_code` | Grant Type |
 | scope | `string[]` (optional) | `['openid']` | Scope |
-| pkce | `boolean` (optional) | `false` | Use PKCE (Proof Key for Code Exchange) |
+| pkce | `boolean` (optional) | `true` | Use PKCE (Proof Key for Code Exchange). Individual provider presets may override this. |
 | state | `boolean` (optional) | `true` | Use state parameter with a random value. If state is not used, the nonce parameter is used to identify the flow. |
 | nonce | `boolean` (optional) | false | Use nonce parameter with a random value. |
+| prompt | `Array<'none'>` \| `Array<'login' \| 'consent' \| 'select_account'>` (optional) | `undefined` | Space-delimited prompt values added to the authorization request. |
 | userNameClaim | `string` (optional) | '' | User name claim that is used to get the user name from the access token as a fallback in case the userinfo endpoint is not provided or the userinfo request fails. |
 | optionalClaims | `string[]` (optional) | `[]` | Claims to be extracted from the id token |
 | logoutUrl | `string` (optional) | '' | Logout endpoint URL |
 | logoutRedirectUri | `string` (optional) | `undefined` | Redirect URI appended to the logout endpoint if configured |
 | scopeInTokenRequest | `boolean` (optional) | false | Include scope in token request |
+| excludeOfflineScopeFromTokenRequest | `boolean` (optional) | `false` | Strip the `offline_access` scope from token and refresh requests for providers that reject it. |
 | tokenRequestType | `'form'` \| `'form-urlencoded'` \| `'json'` (optional) | `'form'` | Token request type |
 | audience | `string` (optional) | - | Audience used for token validation (not included in requests by default, use additionalTokenParameters or additionalAuthParameters to add it) |
 | requiredProperties | `string[]` | `['clientId', 'redirectUri', 'clientSecret', 'authorizationUrl', 'tokenUrl']` | Required properties validated after runtime resolution. `clientSecret` is ignored only when `authenticationScheme` is `none`. |
@@ -81,7 +83,7 @@ export default defineNuxtConfig({
 | exposeAccessToken | `boolean` (optional) | `false` | Expose access token to the client within session object |
 | exposeIdToken | `boolean` (optional) | `false` | Expose raw id token to the client within session object |
 | callbackRedirectUrl | `string` (optional) | `/` | Set a custom redirect url after a successful callback. If explicitly configured, it takes precedence over middleware-provided `callbackRedirectUrl` values |
-| allowedCallbackRedirectUrls | `string[]` (optional) | `[]` | Allowlist for `redirect` query parameters used on callback routes |
+| allowedCallbackRedirectUrls | `string[]` (optional) | `[]` | Allowlist (prefix-matched) for the `redirectUri` login query parameter. A matching value overrides the OAuth `redirect_uri` sent to the provider for that flow. |
 | allowedClientAuthParameters | `string[]` (optional) | `[]` | List of allowed client-side user-added query parameters for the auth request |
 | proxy | `string` (optional) | `undefined` | Proxy URL used for outbound requests to this provider |
 | ignoreProxyCertificateErrors | `boolean` (optional) | `false` | Disable proxy certificate validation (development only, insecure for production) |

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,6 @@ import { defu } from 'defu'
 import { setupDevToolsUI } from './devtools'
 import * as providerPresets from './runtime/providers'
 import { createProviderRuntimeConfig } from './runtime/server/utils/config'
-import { isProductionEnvironment } from './runtime/utils/environment'
 
 // oxlint-disable-next-line typescript-eslint/unbound-method -- createResolver returns a standalone resolve function
 const { resolve } = createResolver(import.meta.url)
@@ -36,7 +35,8 @@ const DEFAULTS: ModuleOptions = {
     maxAuthSessionAge: 300, // 5 minutes
     cookie: {
       sameSite: 'lax',
-      secure: isProductionEnvironment(),
+      // secure is resolved at runtime in the session utils so it reflects the runtime environment
+      // rather than a value frozen at build time.
     },
   },
   providers: {} as ProviderRuntimeConfig,

--- a/src/module.ts
+++ b/src/module.ts
@@ -154,14 +154,17 @@ export {}
       options.defaultProvider = providers[0]
     }
 
-    const isNonProductionEnvironment = !isProductionEnvironment()
+    // Gate the dev subsystem on the build-immutable dev-server flag instead of NODE_ENV.
+    // A production build (nuxi build/generate) always has nuxt.options.dev === false, so the dev
+    // auth-bypass routes can never be baked into a deployed server, regardless of the runtime NODE_ENV.
+    const isDevServer = nuxt.options.dev
 
-    if (options.devMode?.enabled && !isNonProductionEnvironment) {
-      logger.warn('Dev mode is enabled in config but will be ignored in production.')
+    if (options.devMode?.enabled && !isDevServer) {
+      logger.warn('Dev mode is enabled in config but will be ignored outside the dev server.')
     }
 
     // Add default provider routes
-    if (isNonProductionEnvironment && options.devMode?.enabled) {
+    if (isDevServer && options.devMode?.enabled) {
       extendRouteRules('/auth/login', {
         redirect: {
           to: '/auth/dev/login',
@@ -196,7 +199,7 @@ export {}
     }
 
     // Dev mode handler
-    if (isNonProductionEnvironment && options.devMode?.enabled) {
+    if (isDevServer && options.devMode?.enabled) {
       logger.warn('Dev mode is enabled. Do not use in production!')
       logger.info('Dev mode OIDC discovery endpoint: /auth/dev/.well-known/openid-configuration')
 

--- a/src/runtime/plugins/provideDefaults.ts
+++ b/src/runtime/plugins/provideDefaults.ts
@@ -1,18 +1,29 @@
 // @ts-expect-error - Missing Nitro type exports in Nuxt
-import { defineNitroPlugin } from '#imports'
+import { defineNitroPlugin, useRuntimeConfig } from '#imports'
 import { generateRandomUrlSafeString } from '../server/utils/security'
 import { arrayBufferToBase64 } from '../server/utils/encoding'
 
 const webCrypto = globalThis.crypto
 
+// Only reveal generated secrets in full when dev mode is enabled. In any other mode we keep the
+// first five characters and mask the rest so the value is recognizable without leaking it into logs.
+function formatSecretForLog(secret: string, revealFull: boolean): string {
+  if (revealFull) return secret
+  return `${secret.slice(0, 5)}${'*'.repeat(Math.max(0, secret.length - 5))}`
+}
+
 export default defineNitroPlugin(async () => {
+  const revealSecrets = !!useRuntimeConfig().oidc?.devMode?.enabled
+
   if (!process.env.NUXT_OIDC_SESSION_SECRET || process.env.NUXT_OIDC_SESSION_SECRET.length < 48) {
     const randomSecret = generateRandomUrlSafeString()
     process.env.NUXT_OIDC_SESSION_SECRET = randomSecret
     console.warn(
       '[nuxt-oidc-auth]: No session secret set, using a random secret. Please set NUXT_OIDC_SESSION_SECRET in your environment with at least 48 chars.',
     )
-    console.info(`[nuxt-oidc-auth]: NUXT_OIDC_SESSION_SECRET=${randomSecret}`)
+    console.info(
+      `[nuxt-oidc-auth]: NUXT_OIDC_SESSION_SECRET=${formatSecretForLog(randomSecret, revealSecrets)}`,
+    )
   }
   if (!process.env.NUXT_OIDC_TOKEN_KEY) {
     const randomKey = arrayBufferToBase64(
@@ -28,7 +39,9 @@ export default defineNitroPlugin(async () => {
     console.warn(
       '[nuxt-oidc-auth]: No refresh token key set, using a random key. Please set NUXT_OIDC_TOKEN_KEY in your environment. Refresh tokens saved in this session will be inaccessible after a server restart.',
     )
-    console.info(`[nuxt-oidc-auth]: NUXT_OIDC_TOKEN_KEY=${randomKey}`)
+    console.info(
+      `[nuxt-oidc-auth]: NUXT_OIDC_TOKEN_KEY=${formatSecretForLog(randomKey, revealSecrets)}`,
+    )
   }
   if (!process.env.NUXT_OIDC_AUTH_SESSION_SECRET) {
     const randomKey = generateRandomUrlSafeString()
@@ -36,6 +49,8 @@ export default defineNitroPlugin(async () => {
     console.warn(
       '[nuxt-oidc-auth]: No auth session secret set, using a random secret. Please set NUXT_OIDC_AUTH_SESSION_SECRET in your environment.',
     )
-    console.info(`[nuxt-oidc-auth]: NUXT_OIDC_AUTH_SESSION_SECRET=${randomKey}`)
+    console.info(
+      `[nuxt-oidc-auth]: NUXT_OIDC_AUTH_SESSION_SECRET=${formatSecretForLog(randomKey, revealSecrets)}`,
+    )
   }
 })

--- a/src/runtime/providers/cognito.ts
+++ b/src/runtime/providers/cognito.ts
@@ -34,7 +34,8 @@ export const cognito = defineOidcProvider<Record<string, string>, CognitoRequire
       automaticRefresh: true,
       expirationThreshold: 240,
     },
-    exposeIdToken: true,
+    // Keep the ID token server-side by default; enable only when the client needs to read it.
+    exposeIdToken: false,
     logoutRedirectParameterName: 'logout_uri',
   },
   {

--- a/src/runtime/providers/keycloak.ts
+++ b/src/runtime/providers/keycloak.ts
@@ -53,7 +53,9 @@ export const keycloak = defineOidcProvider<KeycloakProviderConfig, KeycloakRequi
     },
     validateAccessToken: true,
     validateIdToken: false,
-    exposeIdToken: true,
+    // Keep the ID token server-side by default. Logout still sends id_token_hint from the encrypted
+    // session, so enable this only when the client actually needs to read the ID token.
+    exposeIdToken: false,
     baseUrl: '',
     logoutUrl: 'protocol/openid-connect/logout',
     logoutRedirectParameterName: 'post_logout_redirect_uri',

--- a/src/runtime/providers/logto.ts
+++ b/src/runtime/providers/logto.ts
@@ -58,7 +58,9 @@ export const logto = defineOidcProvider<LogtoProviderConfig, LogtoRequiredFields
     skipAccessTokenParsing: true,
     validateAccessToken: false,
     validateIdToken: true,
-    exposeIdToken: true,
+    // Keep the ID token server-side by default. Logout still sends id_token_hint from the encrypted
+    // session, so enable this only when the client actually needs to read the ID token.
+    exposeIdToken: false,
   },
   {
     additionalParameters: {

--- a/src/runtime/providers/paypal.ts
+++ b/src/runtime/providers/paypal.ts
@@ -8,6 +8,8 @@ export const paypal = defineOidcProvider<Record<string, string>, PayPalRequiredF
     validateAccessToken: false,
     validateIdToken: false,
     skipAccessTokenParsing: true,
+    // PayPal does not support PKCE; opt out of the base default so no code challenge is sent.
+    pkce: false,
     state: true,
     nonce: true,
     tokenRequestType: 'form-urlencoded',

--- a/src/runtime/server/api/refresh.post.ts
+++ b/src/runtime/server/api/refresh.post.ts
@@ -1,8 +1,12 @@
 import type { UserSession } from '../../types'
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
+import { isSameOriginRequest } from '../utils/request'
 import { getUserSession, refreshUserSession, sessionHooks } from '../utils/session'
 
 export default defineEventHandler(async (event) => {
+  if (!isSameOriginRequest(event)) {
+    throw createError({ statusCode: 403, message: 'Cross-origin request blocked' })
+  }
   try {
     let session = await getUserSession(event)
     if (session) {

--- a/src/runtime/server/api/session.delete.ts
+++ b/src/runtime/server/api/session.delete.ts
@@ -1,7 +1,11 @@
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
+import { isSameOriginRequest } from '../utils/request'
 import { clearUserSession } from '../utils/session'
 
 export default defineEventHandler(async (event) => {
+  if (!isSameOriginRequest(event)) {
+    throw createError({ statusCode: 403, message: 'Cross-origin request blocked' })
+  }
   await clearUserSession(event)
   return { loggedOut: true }
 })

--- a/src/runtime/server/handler/dev.ts
+++ b/src/runtime/server/handler/dev.ts
@@ -13,7 +13,10 @@ import { isProductionEnvironment } from '../../utils/environment'
 export function devEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   const logger = useOidcLogger()
   return eventHandler(async (event: H3Event) => {
-    if (isProductionEnvironment()) {
+    // Primary guard is the build-immutable dev flag: a production build has import.meta.dev === false,
+    // so this branch is statically false and tree-shaken and the dev auth bypass cannot be reached.
+    // The runtime NODE_ENV check stays as defense in depth for a dev server run against a prod env.
+    if (!import.meta.dev || isProductionEnvironment()) {
       throw createError({ statusCode: 404, message: 'Not Found' })
     }
     logger.warn('Using dev auth handler with static auth information')

--- a/src/runtime/server/handler/devDiscovery.ts
+++ b/src/runtime/server/handler/devDiscovery.ts
@@ -1,7 +1,11 @@
 import { useRuntimeConfig } from '#imports'
-import { eventHandler, getRequestURL } from 'h3'
+import { createError, eventHandler, getRequestURL } from 'h3'
+import { isProductionEnvironment } from '../../utils/environment'
 
 export default eventHandler((event) => {
+  if (!import.meta.dev || isProductionEnvironment()) {
+    throw createError({ statusCode: 404, message: 'Not Found' })
+  }
   const config = useRuntimeConfig().oidc.devMode
   const requestUrl = getRequestURL(event)
   const baseUrl = `${requestUrl.protocol}//${requestUrl.host}`

--- a/src/runtime/server/handler/devJwks.ts
+++ b/src/runtime/server/handler/devJwks.ts
@@ -1,8 +1,12 @@
 import { useRuntimeConfig } from '#imports'
-import { eventHandler } from 'h3'
+import { createError, eventHandler } from 'h3'
 import { getDevModeJwks } from '../utils/devModeKeys'
+import { isProductionEnvironment } from '../../utils/environment'
 
 export default eventHandler(async () => {
+  if (!import.meta.dev || isProductionEnvironment()) {
+    throw createError({ statusCode: 404, message: 'Not Found' })
+  }
   const config = useRuntimeConfig().oidc.devMode
   if (config?.tokenAlgorithm === 'symmetric') {
     return { keys: [] }

--- a/src/runtime/server/handler/logout.get.ts
+++ b/src/runtime/server/handler/logout.get.ts
@@ -12,7 +12,7 @@ import {
 } from '../utils/config'
 import { convertObjectToSnakeCase, useOidcLogger } from '../utils/oidc'
 import { withAppBase } from '../utils/redirect'
-import { clearUserSession, getUserSession } from '../utils/session'
+import { clearUserSession, getPersistedIdToken, getUserSession } from '../utils/session'
 
 export function logoutEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
   const logger = useOidcLogger()
@@ -56,12 +56,16 @@ export function logoutEventHandler({ onSuccess }: OAuthConfig<UserSession>) {
           await clearUserSession(event)
           return onSuccess(event, { user: null })
         }
-        Object.keys(config.additionalLogoutParameters).forEach((key) => {
-          if (key === 'idTokenHint' && userSession.idToken)
-            additionalLogoutParameters[key] = userSession.idToken
+        for (const key of Object.keys(config.additionalLogoutParameters)) {
+          if (key === 'idTokenHint') {
+            // Prefer the client-exposed token when available, otherwise read it from the encrypted
+            // server-side session so id_token_hint keeps working without exposing the token to the client.
+            const idTokenHint = userSession.idToken || (await getPersistedIdToken(event))
+            if (idTokenHint) additionalLogoutParameters[key] = idTokenHint
+          }
           if (key === 'logoutHint' && userSession.claims?.login_hint)
             additionalLogoutParameters[key] = userSession.claims.login_hint as string
-        })
+        }
       }
       const location = withQuery(config.logoutUrl, {
         ...(config.logoutRedirectParameterName &&

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -179,7 +179,8 @@ export interface OidcProviderConfig {
   validateIdToken?: boolean
   /**
    * Token validation behavior. Strict mode validates every enabled JWT in callback and refresh token responses without trusting decoded claims first.
-   * @default 'legacy'
+   * Legacy mode only verifies a token when its decoded (unverified) audience matches and otherwise trusts the decoded claims, so it should only be used for backwards compatibility.
+   * @default 'strict'
    */
   tokenValidationMode?: 'legacy' | 'strict'
   /**
@@ -290,7 +291,7 @@ export function defineOidcProvider<
     requiredProperties: ['clientId', 'redirectUri', 'clientSecret', 'authorizationUrl', 'tokenUrl'],
     validateAccessToken: true,
     validateIdToken: true,
-    tokenValidationMode: 'legacy',
+    tokenValidationMode: 'strict',
     skipAccessTokenParsing: false,
     exposeAccessToken: false,
     exposeIdToken: false,

--- a/src/runtime/server/utils/provider.ts
+++ b/src/runtime/server/utils/provider.ts
@@ -83,7 +83,7 @@ export interface OidcProviderConfig {
   excludeOfflineScopeFromTokenRequest?: boolean
   /**
    * Use PKCE (Proof Key for Code Exchange)
-   * @default false
+   * @default true
    */
   pkce?: boolean
   /**

--- a/src/runtime/server/utils/request.ts
+++ b/src/runtime/server/utils/request.ts
@@ -1,0 +1,27 @@
+import type { H3Event } from 'h3'
+import { getRequestHeader, getRequestURL } from 'h3'
+
+/**
+ * Defense-in-depth CSRF check for state-changing endpoints.
+ *
+ * Rejects browser requests whose Origin (or Referer) does not match the request target. Requests
+ * without an Origin or Referer header (for example server-to-server API clients) are allowed, since
+ * the SameSite=Lax session cookie already prevents cross-site browsers from sending credentials.
+ */
+export function isSameOriginRequest(event: H3Event): boolean {
+  const target = getRequestURL(event).origin
+
+  const origin = getRequestHeader(event, 'origin')
+  if (origin) return origin === target
+
+  const referer = getRequestHeader(event, 'referer')
+  if (referer) {
+    try {
+      return new URL(referer).origin === target
+    } catch {
+      return false
+    }
+  }
+
+  return true
+}

--- a/src/runtime/server/utils/security.ts
+++ b/src/runtime/server/utils/security.ts
@@ -10,6 +10,28 @@ import {
 const webCrypto = globalThis.crypto
 const BASE64_DATA_URL_PREFIX_RE = /^data:[^,]*;base64,/
 
+// Reuse the remote JWKS set per jwks_uri. createRemoteJWKSet keeps its own key cache and refetches
+// on key rotation, so recreating it on every validation would defeat that cache and hit the IdP
+// JWKS endpoint on every callback and refresh.
+const remoteJwkSetCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>()
+
+function getRemoteJwkSet(jwksUri: string) {
+  let jwkSet = remoteJwkSetCache.get(jwksUri)
+  if (!jwkSet) {
+    jwkSet = createRemoteJWKSet(new URL(jwksUri))
+    remoteJwkSetCache.set(jwksUri, jwkSet)
+  }
+  return jwkSet
+}
+
+/**
+ * Clear the cached remote JWKS sets. Primarily intended for tests that swap signing keys behind the
+ * same jwks_uri between cases.
+ */
+export function clearRemoteJwkSetCache() {
+  remoteJwkSetCache.clear()
+}
+
 // https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
 export interface JwtPayload {
   iss?: string
@@ -241,7 +263,7 @@ export async function validateToken(
   token: string,
   options: ValidateAccessTokenOptions,
 ): Promise<JwtPayload> {
-  const jwks = createRemoteJWKSet(new URL(options.jwksUri))
+  const jwks = getRemoteJwkSet(options.jwksUri)
   const { payload } = await jwtVerify(token, jwks, {
     issuer: options.issuer,
     audience: options.audience,

--- a/src/runtime/server/utils/security.ts
+++ b/src/runtime/server/utils/security.ts
@@ -67,7 +67,22 @@ export interface ValidateAccessTokenOptions {
   jwksUri: string
   audience?: string | string[]
   requiredClaims?: string[]
+  algorithms?: string[]
 }
+
+// Restrict verification to asymmetric signature algorithms. This excludes `none` and symmetric
+// HMAC algorithms, closing off algorithm-confusion attacks against the remote JWKS.
+const DEFAULT_JWT_ALGORITHMS = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'PS256',
+  'PS384',
+  'PS512',
+]
 
 const unreservedCharacters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~'
 
@@ -231,6 +246,7 @@ export async function validateToken(
     issuer: options.issuer,
     audience: options.audience,
     requiredClaims: options.requiredClaims,
+    algorithms: options.algorithms ?? DEFAULT_JWT_ALGORITHMS,
   })
   return payload as JwtPayload
 }

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -25,6 +25,7 @@ import { refreshAccessToken, useOidcLogger } from './oidc'
 import { withAppBase } from './redirect'
 import { decryptToken, encryptToken, parseJwtToken } from './security'
 import { resolveMissingPersistentSessionMode } from './session-options'
+import { isProductionEnvironment } from '../../utils/environment'
 
 const DEFAULT_SESSION_NAME = 'nuxt-oidc-auth'
 const TOKEN_DERIVED_USER_SESSION_FIELDS = [
@@ -543,6 +544,11 @@ function resolveSessionConfig(config: AuthSessionConfig) {
     {
       password: process.env.NUXT_OIDC_SESSION_SECRET!,
       name: resolveSessionName(config),
+      // Resolve the secure flag at runtime so a production deployment gets Secure cookies even when
+      // the build did not run with a production NODE_ENV. Explicit config still takes precedence.
+      cookie: {
+        secure: config?.cookie?.secure ?? isProductionEnvironment(),
+      },
     },
     config,
   )

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -448,6 +448,21 @@ export async function getUserSessionId(event: H3Event) {
   return (await _useSession(event)).id as string
 }
 
+/**
+ * Read the ID token from the encrypted persistent session storage without exposing it to the client.
+ * Used server-side (for example to build the RP-initiated logout id_token_hint) so it works
+ * independently of the exposeIdToken flag, which only controls client visibility.
+ */
+export async function getPersistedIdToken(event: H3Event): Promise<string | undefined> {
+  const session = await _useSession(event)
+  const persistentSession = (await useStorage('oidc').getItem<PersistentSession>(
+    session.id as string,
+  )) as PersistentSession | null
+  if (!persistentSession?.idToken) return undefined
+  const tokenKey = process.env.NUXT_OIDC_TOKEN_KEY as string
+  return (await decryptToken(persistentSession.idToken, tokenKey)) || undefined
+}
+
 export async function hasEligibleSingleSignOutSessionCookie(event: H3Event): Promise<boolean> {
   const runtimeConfig = useRuntimeConfig(event).oidc
   const config = runtimeConfig.session as AuthSessionConfig

--- a/test/functional/auth-session-duration.test.ts
+++ b/test/functional/auth-session-duration.test.ts
@@ -16,6 +16,7 @@ function createRuntimeConfig(providerMaxAuthSessionAge?: number) {
           clientId: 'functional-client',
           clientSecret: 'functional-secret',
           redirectUri: 'https://app.example.test/auth/oidc/callback',
+          tokenValidationMode: 'legacy',
           requiredProperties: [
             'clientId',
             'clientSecret',

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -53,6 +53,7 @@ function createRuntimeConfig(callbackRedirectUrl?: string, baseURL?: string) {
           authorizationUrl: 'https://identity.example.test/authorize',
           tokenUrl,
           redirectUri: 'https://app.example.test/auth/oidc/callback',
+          tokenValidationMode: 'legacy',
           validateAccessToken: false,
           validateIdToken: false,
           requiredProperties: [

--- a/test/functional/callback-handler.test.ts
+++ b/test/functional/callback-handler.test.ts
@@ -27,7 +27,9 @@ beforeAll(async () => {
   accessToken = await signingFixture.sign({ aud: 'functional-client', sub: 'user-1' })
 })
 
-beforeEach(() => {
+beforeEach(async () => {
+  const { clearRemoteJwkSetCache } = await import('../../src/runtime/server/utils/security')
+  clearRemoteJwkSetCache()
   testLogger.error.mockClear()
   testLogger.info.mockClear()
   testLogger.warn.mockClear()

--- a/test/functional/handler-harness.test.ts
+++ b/test/functional/handler-harness.test.ts
@@ -306,7 +306,8 @@ describe('functional handler harness', () => {
     ).rejects.toThrow()
     expect(fixture.publicJwk).toMatchObject({ alg: 'RS256', kid: 'functional-test-key' })
     expect(fixture.privateJwk.d).toEqual(expect.any(String))
-    expect(interceptor.requests).toHaveLength(2)
+    // The remote JWKS set is cached per jwks_uri, so the second validation reuses the first fetch.
+    expect(interceptor.requests).toHaveLength(1)
     interceptor.restore()
   })
 })

--- a/test/functional/handler-harness.test.ts
+++ b/test/functional/handler-harness.test.ts
@@ -15,6 +15,7 @@ const runtimeConfig = {
         authorizationUrl: 'https://identity.example.test/authorize',
         tokenUrl: 'https://identity.example.test/token',
         redirectUri: 'https://app.example.test/auth/oidc/callback',
+        tokenValidationMode: 'legacy',
         requiredProperties: [
           'clientId',
           'clientSecret',

--- a/test/functional/token-exposure.test.ts
+++ b/test/functional/token-exposure.test.ts
@@ -121,7 +121,7 @@ describe('token exposure overrides', () => {
       name: 'omitted values',
       overrides: {},
       exposeAccessToken: false,
-      exposeIdToken: true,
+      exposeIdToken: false,
     },
   ])('applies $name to initial and refreshed sessions', async (testCase) => {
     const initialHarness = new HandlerHarness({

--- a/test/unit/utils/config.test.ts
+++ b/test/unit/utils/config.test.ts
@@ -37,6 +37,7 @@ vi.mock('#imports', () => ({
 }))
 
 const publicKeycloakConfig = {
+  audience: 'https://api.example.com',
   authenticationScheme: 'none',
   baseUrl: 'https://issuer.example.com/realms/example',
   clientId: 'public-client',
@@ -206,14 +207,14 @@ describe('configuration Utilities', () => {
   })
 
   describe('resolved provider configuration', () => {
-    it('defaults token validation mode to legacy and preserves runtime overrides', () => {
-      expect(resolveProviderConfig({}, oidc).tokenValidationMode).toBe('legacy')
+    it('defaults token validation mode to strict and preserves runtime overrides', () => {
+      expect(resolveProviderConfig({}, oidc).tokenValidationMode).toBe('strict')
       expect(
         resolveProviderConfig(
-          createProviderRuntimeConfig({ tokenValidationMode: 'strict' }, oidc),
+          createProviderRuntimeConfig({ tokenValidationMode: 'legacy' }, oidc),
           oidc,
         ).tokenValidationMode,
-      ).toBe('strict')
+      ).toBe('legacy')
     })
 
     it('rejects an invalid runtime token validation mode', () => {
@@ -402,6 +403,7 @@ describe('configuration Utilities', () => {
       }
       const runtimeProvider = {
         ...createProviderRuntimeConfig(configuredProvider, keycloak),
+        audience: 'https://api.example.com',
         baseUrl: 'https://runtime.example.com/realms/example',
         clientId: 'runtime-client',
         clientSecret: 'runtime-secret',
@@ -815,6 +817,7 @@ describe('configuration Utilities', () => {
     it('accepts explicit Keycloak endpoints and discovery metadata without a base URL', () => {
       const config = resolveProviderConfig(
         {
+          audience: 'https://api.example.com',
           authenticationScheme: 'none',
           authorizationUrl: 'https://issuer.example.com/authorize',
           clientId: 'public-client',

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -2,6 +2,10 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  // Mirror the dev server so the build-immutable dev guards in the dev handlers are active under test.
+  define: {
+    'import.meta.dev': 'true',
+  },
   test: {
     // Global test configuration
     globals: true,


### PR DESCRIPTION
## Summary

Security audit follow-up for the pre-beta.12 line. Hardens authentication defaults, closes a dev-mode auth-bypass path, and syncs the documentation with the resulting behavior.

## Breaking changes

- **`tokenValidationMode` now defaults to `strict`.** Previously `legacy`, which decided whether to cryptographically verify a token based on the *unverified, decoded* `aud` claim — a non-matching audience meant signature verification was skipped entirely and the decoded claims became the session identity. Strict access-token validation requires `audience`, and any enabled strict validation requires discovery metadata (`issuer` + `jwks_uri`). Set `tokenValidationMode: 'legacy'` per provider to restore the old behavior.
- **`exposeIdToken` now defaults to `false`** for the Keycloak, Cognito, and Logto presets. The raw ID token is no longer placed in the client-visible session / SSR payload by default. RP-initiated logout still works: `id_token_hint` is now read from the encrypted server-side session via a new internal helper, so logout no longer depends on client exposure.

## Security fixes

- **Dev auth endpoints gated on the build-immutable dev flag.** `/auth/dev/login` mints a fully authenticated session with no credentials. Both registration and the runtime guard previously keyed off mutable `process.env.NODE_ENV`, which fails open when unset. Registration now uses `nuxt.options.dev` and the handlers use `import.meta.dev` (plus the runtime production check as defense in depth), so the routes can never be baked into a production build. This also adds the previously missing runtime guard to the dev discovery and JWKS handlers.
- **Generated secrets masked in logs.** Auto-generated `NUXT_OIDC_SESSION_SECRET`, `NUXT_OIDC_TOKEN_KEY`, and `NUXT_OIDC_AUTH_SESSION_SECRET` values were printed in full via `console.info`. They are now shown as the first five characters followed by asterisks unless dev mode is enabled.
- **Cookie `secure` flag resolved at runtime** instead of baked from `NODE_ENV` at build time, so a production deployment gets `Secure` cookies even when the build did not run with a production `NODE_ENV`. Explicit config still wins.
- **Cross-origin protection** on `DELETE /api/_auth/session` and `POST /api/_auth/refresh` (403 on Origin/Referer mismatch) as defense in depth beyond `SameSite=Lax`. Requests without either header (server-to-server) remain allowed.
- **Explicit JWT algorithm allowlist** pinned for verification (asymmetric RS/ES/PS only), excluding `none` and HMAC.
- **Remote JWKS sets cached per `jwks_uri`** instead of being recreated on every validation, which previously defeated the key cache and hit the IdP JWKS endpoint on every callback and refresh.

## Other fixes

- **PayPal preset now sets `pkce: false`.** It silently inherited the base default `pkce: true` while the docs correctly state PayPal does not support PKCE.

## Documentation

Synced the docs with the above and corrected pre-existing drift found while auditing: `pkce` default was documented as `false` but is `true`; all Microsoft examples used the wrong `entra:` provider key; Microsoft `prompt` default was wrong; `allowedCallbackRedirectUrls` described the wrong query parameter; the generic OIDC defaults block and env-var placeholder were stale; added missing `prompt` and `excludeOfflineScopeFromTokenRequest` reference rows.

## Testing

`pnpm test` — 379 passing across 30 files. `pnpm lint:ox` clean. Test fixtures that encoded the old defaults were updated (legacy-mode flows pinned explicitly, JWKS fetch-count expectation adjusted for caching).
